### PR TITLE
LTの登録を削除するボタンの実装

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,8 @@ model LightningTalk {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
+  notificationMessage NotificationMessage?
+
   @@map("lightning_talks")
 }
 
@@ -29,4 +31,13 @@ enum State {
   DONE
 
   @@map("states")
+}
+
+model NotificationMessage {
+  id              Int           @id @default(autoincrement())
+  messageId       String        @unique @map("message_id")
+  lightningTalk   LightningTalk @relation(fields: [lightningTalkId], references: [id], onDelete: Cascade)
+  lightningTalkId Int           @unique @map("lightning_talk_id")
+
+  @@map("notification_messages")
 }

--- a/src/buttons/deleteLTButton.ts
+++ b/src/buttons/deleteLTButton.ts
@@ -1,5 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from "discord.js";
 import type { Button } from "../types";
+import { deleteLTByButton } from "../services/LTManagementService";
 
 export const deleteLTButton: Button = {
     create: (ltId: string) => {
@@ -12,7 +13,7 @@ export const deleteLTButton: Button = {
         return interaction.customId.startsWith('delete-lt-');
     },
     onClick: async (interaction) => {
-        interaction.deferReply();
-        interaction.editReply('削除しました');
+        await interaction.deferUpdate();
+        await deleteLTByButton(interaction);
     }
 }

--- a/src/buttons/deleteLTButton.ts
+++ b/src/buttons/deleteLTButton.ts
@@ -1,0 +1,18 @@
+import { ButtonBuilder, ButtonStyle } from "discord.js";
+import type { Button } from "../types";
+
+export const deleteLTButton: Button = {
+    create: (ltId: string) => {
+        return new ButtonBuilder()
+            .setCustomId(`delete-lt-${ltId}`)
+            .setLabel('削除')
+            .setStyle(ButtonStyle.Danger)
+    },
+    isThisButton: (interaction) => {
+        return interaction.customId.startsWith('delete-lt-');
+    },
+    onClick: async (interaction) => {
+        interaction.deferReply();
+        interaction.editReply('削除しました');
+    }
+}

--- a/src/buttons/index.ts
+++ b/src/buttons/index.ts
@@ -1,0 +1,9 @@
+import type { Button } from '../types';
+import { deleteLTButton } from './deleteLTButton';
+
+
+const buttons: Button[] = [
+    deleteLTButton
+];
+
+export default buttons;

--- a/src/eventHandlers/interactionCreateHandler.ts
+++ b/src/eventHandlers/interactionCreateHandler.ts
@@ -1,5 +1,6 @@
 import { MessageFlags, type Interaction } from "discord.js";
 import commands from "../commands";
+import buttons from "../buttons";
 
 export const interactionCreateHandler = async (interaction: Interaction) => {
     console.log('interactionCreateHandler start');
@@ -17,9 +18,20 @@ export const interactionCreateHandler = async (interaction: Interaction) => {
         } else {
             await interaction.reply({ content: 'Unknown command.', flags: MessageFlags.Ephemeral });
         }
+    } else if (interaction.isButton()) {
+        const button = buttons.find(button => button.isThisButton(interaction));
+
+        if (button) {
+            try {
+                await button.onClick(interaction);
+            } catch (error) {
+                console.error('Failed to execute button', error);
+                await interaction.reply({ content: 'Failed to execute button.', ephemeral: true });
+            }
+        } else {
+            await interaction.reply({ content: 'Unknown button.', ephemeral: true });
+        }
     }
-
-
 
     console.log('interactionCreateHandler end');
 }

--- a/src/eventHandlers/interactionCreateHandler.ts
+++ b/src/eventHandlers/interactionCreateHandler.ts
@@ -9,8 +9,8 @@ export const interactionCreateHandler = async (interaction: Interaction) => {
         const command = commands.find(command => command.isThisCommand(interaction));
 
         if (command) {
-            try{
-            await command.execute(interaction);
+            try {
+                await command.execute(interaction);
             } catch (error) {
                 console.error('Failed to execute command', error);
                 await interaction.editReply({ content: 'Failed to execute command.' });
@@ -26,10 +26,10 @@ export const interactionCreateHandler = async (interaction: Interaction) => {
                 await button.onClick(interaction);
             } catch (error) {
                 console.error('Failed to execute button', error);
-                await interaction.reply({ content: 'Failed to execute button.', ephemeral: true });
+                await interaction.editReply({ content: 'Failed to execute button.' });
             }
         } else {
-            await interaction.reply({ content: 'Unknown button.', ephemeral: true });
+            await interaction.editReply({ content: 'Unknown button.' });
         }
     }
 

--- a/src/services/LTManagementService.ts
+++ b/src/services/LTManagementService.ts
@@ -1,6 +1,7 @@
-import { CommandInteraction } from "discord.js";
-import { insertLT } from "../tables/lightningTalkTable";
+import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, CommandInteraction } from "discord.js";
+import { deleteLTById, insertLT } from "../tables/lightningTalkTable";
 import { notifyLTRegistration } from "./LTNotificationService";
+import { deleteLTButton } from "../buttons/deleteLTButton";
 
 export const registerLTByCommand = async (interaction: CommandInteraction) => {
     console.log('registerLTByCommand start');
@@ -31,8 +32,12 @@ export const registerLTByCommand = async (interaction: CommandInteraction) => {
         });
         return;
     } else {
+        const row = new ActionRowBuilder<ButtonBuilder>()
+            .addComponents(deleteLTButton.create(lt.id.toString()));
+
         await interaction.editReply({
-            content: `以下のLTを登録しました！\n 「${lt.title}」（${(ready ? '発表可能' : '準備中')}）${lt.description && "\n 概要: "+lt.description}`,
+            content: `以下のLTを登録しました！\n 「${lt.title}」（${(ready ? '発表可能' : '準備中')}）${lt.description && "\n 概要: " + lt.description}`,
+            components: [row],
         });
     }
 

--- a/src/services/LTManagementService.ts
+++ b/src/services/LTManagementService.ts
@@ -10,9 +10,7 @@ export const registerLTByCommand = async (interaction: CommandInteraction) => {
     const ready = interaction.options.get('ready')?.value;
     if (title === undefined || ready === undefined) {
         console.error('title or ready is empty\n title: ' + title + ', ready: ' + ready);
-        await interaction.editReply({
-            content: 'Failed to register LT',
-        });
+        await interaction.editReply({ content: 'Failed to register LT' });
         return;
     }
 
@@ -27,9 +25,7 @@ export const registerLTByCommand = async (interaction: CommandInteraction) => {
 
     if (error || !lt) {
         console.error('insert error', error);
-        await interaction.editReply({
-            content: 'Failed to register LT',
-        });
+        await interaction.editReply({ content: 'Failed to register LT' });
         return;
     } else {
         const row = new ActionRowBuilder<ButtonBuilder>()
@@ -44,4 +40,31 @@ export const registerLTByCommand = async (interaction: CommandInteraction) => {
     await notifyLTRegistration(interaction.client, lt);
 
     console.log('registerLTByCommand end');
+}
+
+
+export const deleteLTByButton = async (interaction: ButtonInteraction) => {
+    console.log('deleteLTByButton start');
+
+    // この時点でltIdは「delete-lt-<ltId>」の形式になっているかどうかを確認する
+    if (!interaction.customId.startsWith('delete-lt-')) {
+        console.error('ltId is empty');
+        await interaction.editReply({ content: 'Failed to delete LT' });
+        return;
+    }
+
+    const ltId = parseInt(interaction.customId.split('-')[2]);
+
+    const { lt, error } = await deleteLTById(ltId);
+    if (error || !lt) {
+        console.error('delete error', error);
+        await interaction.editReply({ content: 'Failed to delete LT' });
+        return;
+    } else {
+        const newContent = '削除済み\n' + interaction.message.content.split('\n').map((line) => '~~' + line + '~~').join('\n');
+        console.log('newContent', newContent);
+        await interaction.editReply({ content: newContent, components: [] });
+    }
+
+    console.log('deleteLTByButton end');
 }

--- a/src/services/LTManagementService.ts
+++ b/src/services/LTManagementService.ts
@@ -1,6 +1,6 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, CommandInteraction } from "discord.js";
 import { deleteLTById, insertLT } from "../tables/lightningTalkTable";
-import { editNotificationMessageById, notifyLTRegistration } from "./LTNotificationService";
+import { deleteNotificationMessageById, notifyLTRegistration } from "./LTNotificationService";
 import { deleteLTButton } from "../buttons/deleteLTButton";
 import { deleteNotificationMessage } from "../tables/notificationMessageTable";
 
@@ -70,7 +70,7 @@ export const deleteLTByButton = async (interaction: ButtonInteraction) => {
         await interaction.editReply({ content: newContent, components: [] });
 
         if (notificationMessage) {
-            await editNotificationMessageById(interaction.client, notificationMessage.messageId);
+            await deleteNotificationMessageById(interaction.client, notificationMessage.messageId);
         }
     }
 

--- a/src/services/LTManagementService.ts
+++ b/src/services/LTManagementService.ts
@@ -1,7 +1,8 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, CommandInteraction } from "discord.js";
 import { deleteLTById, insertLT } from "../tables/lightningTalkTable";
-import { notifyLTRegistration } from "./LTNotificationService";
+import { editNotificationMessageById, notifyLTRegistration } from "./LTNotificationService";
 import { deleteLTButton } from "../buttons/deleteLTButton";
+import { deleteNotificationMessage } from "../tables/notificationMessageTable";
 
 export const registerLTByCommand = async (interaction: CommandInteraction) => {
     console.log('registerLTByCommand start');
@@ -55,15 +56,22 @@ export const deleteLTByButton = async (interaction: ButtonInteraction) => {
 
     const ltId = parseInt(interaction.customId.split('-')[2]);
 
-    const { lt, error } = await deleteLTById(ltId);
-    if (error || !lt) {
-        console.error('delete error', error);
+    // 先に子要素である通知メッセージを削除し、message idを取得しておく
+    const { notificationMessage } = await deleteNotificationMessage(ltId);
+
+    const { lt, error: ltError } = await deleteLTById(ltId);
+    if (ltError || !lt) {
+        console.error('delete error', ltError);
         await interaction.editReply({ content: 'Failed to delete LT' });
         return;
     } else {
         const newContent = '削除済み\n' + interaction.message.content.split('\n').map((line) => '~~' + line + '~~').join('\n');
         console.log('newContent', newContent);
         await interaction.editReply({ content: newContent, components: [] });
+
+        if (notificationMessage) {
+            await editNotificationMessageById(interaction.client, notificationMessage.messageId);
+        }
     }
 
     console.log('deleteLTByButton end');

--- a/src/services/LTNotificationService.ts
+++ b/src/services/LTNotificationService.ts
@@ -1,6 +1,7 @@
 import { roleMention, userMention, type Client, type TextChannel } from "discord.js";
 import type { LightningTalk } from "@prisma/client";
-import { insertNotificationMessage } from "../tables/notificationMessageTable";
+import { deleteNotificationMessage, insertNotificationMessage } from "../tables/notificationMessageTable";
+import { map } from "zod";
 
 const { NOTIFICATION_CHANNEL_ID, ROLE_ID } = process.env;
 
@@ -27,3 +28,14 @@ export const notifyLTRegistration = async (client: Client, lt: LightningTalk) =>
     console.log('end announceRegisterLT');
 }
 
+export const editNotificationMessageById = async (client: Client, messageId:string) => {
+    console.log('start deleteNotificationMessageById');
+
+    const channel = client.channels.cache.get(NOTIFICATION_CHANNEL_ID) as TextChannel;
+    const message = await channel.messages.fetch(messageId);
+    console.log('message', message.content);
+
+    await message.edit('このLTは削除されました\n' + message.content.split('\n').map((line) => '~~' + line + '~~').join('\n'));
+
+    console.log('end deleteNotificationMessageById');
+}

--- a/src/services/LTNotificationService.ts
+++ b/src/services/LTNotificationService.ts
@@ -28,7 +28,8 @@ export const notifyLTRegistration = async (client: Client, lt: LightningTalk) =>
     console.log('end announceRegisterLT');
 }
 
-export const editNotificationMessageById = async (client: Client, messageId:string) => {
+/* 完全に削除するのではなく、罫線を引いて削除したことを示す */
+export const deleteNotificationMessageById = async (client: Client, messageId:string) => {
     console.log('start deleteNotificationMessageById');
 
     const channel = client.channels.cache.get(NOTIFICATION_CHANNEL_ID) as TextChannel;

--- a/src/services/LTNotificationService.ts
+++ b/src/services/LTNotificationService.ts
@@ -1,5 +1,6 @@
 import { roleMention, userMention, type Client, type TextChannel } from "discord.js";
 import type { LightningTalk } from "@prisma/client";
+import { insertNotificationMessage } from "../tables/notificationMessageTable";
 
 const { NOTIFICATION_CHANNEL_ID, ROLE_ID } = process.env;
 
@@ -20,7 +21,8 @@ export const notifyLTRegistration = async (client: Client, lt: LightningTalk) =>
         notificationMessage.push(`概要：${lt.description}`);
     }
 
-    await channel?.send(notificationMessage.join('\n'));
+    const sendMessage = await channel?.send(notificationMessage.join('\n'));
+    insertNotificationMessage(lt.id, sendMessage.id);
 
     console.log('end announceRegisterLT');
 }

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -1,9 +1,9 @@
-import { PrismaClient, type LightningTalk } from "@prisma/client";
+import { PrismaClient, State, type LightningTalk } from "@prisma/client";
 
 export const insertLT = async (title: string, speaker: string, ready: boolean, description?: string): Promise<{ lt: LightningTalk | null, error: any }> => {
     console.log('start insertLT');
 
-    const state = ready ? 'READY' : 'UNREADY';
+    const state: State = ready ? 'READY' : 'UNREADY';
     const prisma = new PrismaClient();
 
     try {

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -27,3 +27,26 @@ export const insertLT = async (title: string, speaker: string, ready: boolean, d
     }
 }
 
+
+export const deleteLTById = async (id: number): Promise<{ lt: LightningTalk | null, error: any }> => {
+    console.log('start deleteLTById');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const lt: LightningTalk = await prisma.lightningTalk.delete({
+            where: {
+                id
+            }
+        });
+        console.log('deleteLTById', lt);
+
+        return { lt, error: null };
+    } catch (error: any) {
+        console.error('Failed to deleteLTById', error);
+        return { lt: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end deleteLTById');
+    }
+}

--- a/src/tables/notificationMessageTable.ts
+++ b/src/tables/notificationMessageTable.ts
@@ -24,3 +24,26 @@ export const insertNotificationMessage = async (lightningTalkId: number, message
         console.log('end insertNotificationMessage');
     }
 }
+
+export const deleteNotificationMessage = async (lightningTalkId: number): Promise<{ notificationMessage: NotificationMessage | null, error: any }> => {
+    console.log('start deleteNotificationMessage');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const notificationMessage: NotificationMessage = await prisma.notificationMessage.delete({
+            where: {
+                lightningTalkId
+            }
+        });
+        console.log('deleteNotificationMessage', notificationMessage);
+
+        return { notificationMessage, error: null };
+    } catch (error: any) {
+        console.error('Failed to deleteNotificationMessage', error);
+        return { notificationMessage: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end deleteNotificationMessage');
+    }
+}

--- a/src/tables/notificationMessageTable.ts
+++ b/src/tables/notificationMessageTable.ts
@@ -1,0 +1,26 @@
+import { type NotificationMessage, PrismaClient } from "@prisma/client";
+
+
+export const insertNotificationMessage = async (lightningTalkId: number, messageId: string): Promise<{ notificationMessage: NotificationMessage | null, error: any }> => {
+    console.log('start insertNotificationMessage');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const notificationMessage: NotificationMessage = await prisma.notificationMessage.create({
+            data: {
+                lightningTalkId,
+                messageId
+            }
+        });
+        console.log('insertNotificationMessage', notificationMessage);
+
+        return { notificationMessage, error: null };
+    } catch (error: any) {
+        console.error('Failed to insertNotificationMessage', error);
+        return { notificationMessage: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end insertNotificationMessage');
+    }
+}

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,0 +1,7 @@
+import type { ButtonComponent, ButtonInteraction } from "discord.js";
+
+export type Button = {
+    create: (...args: any[]) => ButtonComponent;
+    isThisButton: (Interaction: ButtonInteraction) => boolean;
+    onClick: (interaction: ButtonInteraction) => Promise<void>;
+};

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,7 +1,7 @@
-import type { ButtonComponent, ButtonInteraction } from "discord.js";
+import type { ButtonBuilder, ButtonInteraction } from "discord.js";
 
 export type Button = {
-    create: (...args: any[]) => ButtonComponent;
+    create: (...args: any[]) => ButtonBuilder
     isThisButton: (Interaction: ButtonInteraction) => boolean;
     onClick: (interaction: ButtonInteraction) => Promise<void>;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,3 @@
 export * from "./command";
+export * from "./button";
+


### PR DESCRIPTION
登録成功時のephemeral replyに削除ボタンを追加し、それによりLTの登録を削除できる。
また削除後、そのreplyとnotificationのメッセージを編集し、削除されたことを分かるようにした。

削除前
![image](https://github.com/user-attachments/assets/fea3c4bb-6f40-4263-8ca8-dc3592c53d7d)
削除後
![image](https://github.com/user-attachments/assets/2fa5f5e0-c235-4473-8585-6c35f79e72f8)


### データベーススキーマの変更:
- 通知メッセージIdを保存しておくため、`notificationMessage` を追加
- LTテーブルと一対一のリレーションを組んだ

### Lightning Talkの削除用ボタンインタラクション:
* ボタンインタラクションによるLightning Talkの削除を処理するために、`src/buttons/deleteLTButton.ts` に新しい `deleteLTButton` を作成
* `interactionCreateHandler` を更新し、ボタン操作を処理して適切なボタンアクションを実行するよう変更 [[1]](diffhunk://#diff-6dccb6927bfda347493757520beb0cebc50368cd98dff8290e13cb363458e65cR3) [[2]](diffhunk://#diff-6dccb6927bfda347493757520beb0cebc50368cd98dff8290e13cb363458e65cL20-R34)

### Lightning Talk 管理機能の強化:
* `src/services/LTManagementService.ts` の `registerLTByCommand` を変更し、LTの登録時に削除ボタンを含めるようにした[[1]](diffhunk://#diff-06b99e162310f94f0f59af6427cace637834a81b91db962205c88676a4eaf69bL1-R5) [[2]](diffhunk://#diff-06b99e162310f94f0f59af6427cace637834a81b91db962205c88676a4eaf69bL12-R14) [[3]](diffhunk://#diff-06b99e162310f94f0f59af6427cace637834a81b91db962205c88676a4eaf69bL29-R78)
* LTおよび通知メッセージの削除（罫線を引く編集）を処理するための新しい関数 `deleteLTByButton` を追加。
  * 通知メッセージに関しては、`src/services/LTNotificationServices.ts`に実装し、ここで呼び出している

### 通知メッセージの管理:
* `notifyLTRegistration` を更新し、通知メッセージの詳細をデータベースに保存するようにした
* 関連するLTが削除されたときに通知メッセージを削除済みとしてマークする新しい関数 `deleteNotificationMessageById` を追加
* `src/tables/notificationMessageTable.ts` に通知メッセージの挿入と削除用の関数を実装
