### PR TITLE
準備中、準備完了状態をスイッチするボタンの追加

### DIFF
--- a/src/buttons/index.ts
+++ b/src/buttons/index.ts
@@ -1,9 +1,13 @@
 import type { Button } from '../types';
 import { deleteLTButton } from './deleteLTButton';
+import { readyLTButton } from './readyLTButton';
+import { unreadyLTButton } from './unreadyLTButtons';
 
 
 const buttons: Button[] = [
-    deleteLTButton
+    deleteLTButton,
+    readyLTButton,
+    unreadyLTButton
 ];
 
 export default buttons;

--- a/src/buttons/readyLTButton.ts
+++ b/src/buttons/readyLTButton.ts
@@ -1,6 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from "discord.js";
 import type { Button } from "../types";
-import { changeToReadyLTByButton } from "../services/LTManagementService";
+import { switchLTReadyStateByButton } from "../services/LTManagementService";
 
 export const readyLTButton: Button = {
     create: (ltId: string) => {
@@ -14,6 +14,6 @@ export const readyLTButton: Button = {
     },
     onClick: async (interaction) => {
         await interaction.deferUpdate();
-        await changeToReadyLTByButton(interaction);
+        await switchLTReadyStateByButton(interaction, false);
     }
 }

--- a/src/buttons/readyLTButton.ts
+++ b/src/buttons/readyLTButton.ts
@@ -1,0 +1,17 @@
+import { ButtonBuilder, ButtonStyle } from "discord.js";
+import type { Button } from "../types";
+
+export const readyLTButton: Button = {
+    create: (ltId: string) => {
+        return new ButtonBuilder()
+            .setCustomId(`ready-lt-${ltId}`)
+            .setLabel('準備完了')
+            .setStyle(ButtonStyle.Primary)
+    },
+    isThisButton: (interaction) => {
+        return interaction.customId.startsWith('ready-lt-');
+    },
+    onClick: async (interaction) => {
+        await interaction.reply('発表準備完了ですね！:tada:');
+    }
+}

--- a/src/buttons/readyLTButton.ts
+++ b/src/buttons/readyLTButton.ts
@@ -1,5 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from "discord.js";
 import type { Button } from "../types";
+import { changeToReadyLTByButton } from "../services/LTManagementService";
 
 export const readyLTButton: Button = {
     create: (ltId: string) => {
@@ -12,6 +13,7 @@ export const readyLTButton: Button = {
         return interaction.customId.startsWith('ready-lt-');
     },
     onClick: async (interaction) => {
-        await interaction.reply('発表準備完了ですね！:tada:');
+        await interaction.deferUpdate();
+        await changeToReadyLTByButton(interaction);
     }
 }

--- a/src/buttons/unreadyLTButtons.ts
+++ b/src/buttons/unreadyLTButtons.ts
@@ -1,6 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from "discord.js";
 import type { Button } from "../types";
-import { changeToUnreadyLTByButton } from "../services/LTManagementService";
+import { switchLTReadyStateByButton } from "../services/LTManagementService";
 
 export const unreadyLTButton: Button = {
     create: (ltId: string) => {
@@ -14,6 +14,6 @@ export const unreadyLTButton: Button = {
     },
     onClick: async (interaction) => {
         await interaction.deferUpdate();
-        await changeToUnreadyLTByButton(interaction);
+        await switchLTReadyStateByButton(interaction, true);
     }
 }

--- a/src/buttons/unreadyLTButtons.ts
+++ b/src/buttons/unreadyLTButtons.ts
@@ -1,0 +1,17 @@
+import { ButtonBuilder, ButtonStyle } from "discord.js";
+import type { Button } from "../types";
+
+export const unreadyLTButton: Button = {
+    create: (ltId: string) => {
+        return new ButtonBuilder()
+            .setCustomId(`unready-lt-${ltId}`)
+            .setLabel('準備中に戻す')
+            .setStyle(ButtonStyle.Secondary)
+    },
+    isThisButton: (interaction) => {
+        return interaction.customId.startsWith('unready-lt-');
+    },
+    onClick: async (interaction) => {
+        await interaction.reply('発表準備中に戻しました:');
+    }
+}

--- a/src/buttons/unreadyLTButtons.ts
+++ b/src/buttons/unreadyLTButtons.ts
@@ -1,5 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from "discord.js";
 import type { Button } from "../types";
+import { changeToUnreadyLTByButton } from "../services/LTManagementService";
 
 export const unreadyLTButton: Button = {
     create: (ltId: string) => {
@@ -12,6 +13,7 @@ export const unreadyLTButton: Button = {
         return interaction.customId.startsWith('unready-lt-');
     },
     onClick: async (interaction) => {
-        await interaction.reply('発表準備中に戻しました:');
+        await interaction.deferUpdate();
+        await changeToUnreadyLTByButton(interaction);
     }
 }

--- a/src/services/LTManagementService.ts
+++ b/src/services/LTManagementService.ts
@@ -1,5 +1,5 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, CommandInteraction } from "discord.js";
-import { deleteLTById, insertLT } from "../tables/lightningTalkTable";
+import { deleteLTById, insertLT, updateLTStateById } from "../tables/lightningTalkTable";
 import { deleteNotificationMessageById, notifyLTRegistration } from "./LTNotificationService";
 import { deleteLTButton } from "../buttons/deleteLTButton";
 import { deleteNotificationMessage } from "../tables/notificationMessageTable";
@@ -78,4 +78,49 @@ export const deleteLTByButton = async (interaction: ButtonInteraction) => {
     }
 
     console.log('deleteLTByButton end');
+}
+
+
+export const changeToReadyLTByButton = async (interaction: ButtonInteraction) => {
+    console.log('readyLTByButton start');
+
+    if (!interaction.customId.startsWith('ready-lt-')) {
+        console.error('ltId is empty');
+        await interaction.editReply({ content: 'Failed to ready LT' });
+        return;
+    }
+
+    const ltId = parseInt(interaction.customId.split('-')[2]);
+
+    const { lt, error } = await updateLTStateById(ltId, 'READY');
+
+    // ltが取得できている場合は変更が成功しているとみなす => 既にREADYの場合も成功扱い
+    if (lt) {
+        await interaction.editReply({ content: `「${lt.title}」を発表可能にしました！` });
+    } else {
+        console.error('update error', error);
+        await interaction.editReply({ content: 'Failed to ready LT' });
+    }
+}
+
+export const changeToUnreadyLTByButton = async (interaction: ButtonInteraction) => {
+    console.log('unreadyLTByButton start');
+
+    if (!interaction.customId.startsWith('unready-lt-')) {
+        console.error('ltId is empty');
+        await interaction.editReply({ content: 'Failed to unready LT' });
+        return;
+    }
+
+    const ltId = parseInt(interaction.customId.split('-')[2]);
+
+    const { lt, error } = await updateLTStateById(ltId, 'UNREADY');
+
+    // ltが取得できている場合は変更が成功しているとみなす => 既にUNREADYの場合も成功扱い
+    if (lt) {
+        await interaction.editReply({ content: `「${lt.title}」を準備中に戻しました！` });
+    } else {
+        console.error('update error', error);
+        await interaction.editReply({ content: 'Failed to unready LT' });
+    }
 }

--- a/src/services/LTManagementService.ts
+++ b/src/services/LTManagementService.ts
@@ -96,7 +96,20 @@ export const changeToReadyLTByButton = async (interaction: ButtonInteraction) =>
 
     // ltが取得できている場合は変更が成功しているとみなす => 既にREADYの場合も成功扱い
     if (lt) {
-        await interaction.editReply({ content: `「${lt.title}」を発表可能にしました！` });
+        const newComponents = interaction.message.components.map((row) => {
+            return new ActionRowBuilder<ButtonBuilder>().addComponents(
+                row.components.map((component) => {
+                    if (component.customId?.startsWith('ready-lt-')) {
+                        return unreadyLTButton.create(lt.id.toString());
+                    }
+                    return component;
+                }) as ButtonBuilder[]
+            );
+        });
+
+        const newContent = interaction.message.content.replace('準備中', '発表可能');
+
+        await interaction.editReply({ content: newContent, components: newComponents });
     } else {
         console.error('update error', error);
         await interaction.editReply({ content: 'Failed to ready LT' });
@@ -118,7 +131,20 @@ export const changeToUnreadyLTByButton = async (interaction: ButtonInteraction) 
 
     // ltが取得できている場合は変更が成功しているとみなす => 既にUNREADYの場合も成功扱い
     if (lt) {
-        await interaction.editReply({ content: `「${lt.title}」を準備中に戻しました！` });
+        const newComponents = interaction.message.components.map((row) => {
+            return new ActionRowBuilder<ButtonBuilder>().addComponents(
+                row.components.map((component) => {
+                    if (component.customId?.startsWith('unready-lt-')) {
+                        return readyLTButton.create(lt.id.toString());
+                    }
+                    return component;
+                }) as ButtonBuilder[]
+            );
+        });
+
+        const newContent = interaction.message.content.replace('発表可能', '準備中');
+
+        await interaction.editReply({ content: newContent, components: newComponents });
     } else {
         console.error('update error', error);
         await interaction.editReply({ content: 'Failed to unready LT' });

--- a/src/services/LTManagementService.ts
+++ b/src/services/LTManagementService.ts
@@ -3,6 +3,8 @@ import { deleteLTById, insertLT } from "../tables/lightningTalkTable";
 import { deleteNotificationMessageById, notifyLTRegistration } from "./LTNotificationService";
 import { deleteLTButton } from "../buttons/deleteLTButton";
 import { deleteNotificationMessage } from "../tables/notificationMessageTable";
+import { readyLTButton } from "../buttons/readyLTButton";
+import { unreadyLTButton } from "../buttons/unreadyLTButtons";
 
 export const registerLTByCommand = async (interaction: CommandInteraction) => {
     console.log('registerLTByCommand start');
@@ -30,7 +32,8 @@ export const registerLTByCommand = async (interaction: CommandInteraction) => {
         return;
     } else {
         const row = new ActionRowBuilder<ButtonBuilder>()
-            .addComponents(deleteLTButton.create(lt.id.toString()));
+            .addComponents(deleteLTButton.create(lt.id.toString()))
+            .addComponents(ready ? unreadyLTButton.create(lt.id.toString()) : readyLTButton.create(lt.id.toString()));
 
         await interaction.editReply({
             content: `以下のLTを登録しました！\n 「${lt.title}」（${(ready ? '発表可能' : '準備中')}）${lt.description && "\n 概要: " + lt.description}`,

--- a/src/services/LTManagementService.ts
+++ b/src/services/LTManagementService.ts
@@ -81,72 +81,42 @@ export const deleteLTByButton = async (interaction: ButtonInteraction) => {
 }
 
 
-export const changeToReadyLTByButton = async (interaction: ButtonInteraction) => {
-    console.log('readyLTByButton start');
+export const switchLTReadyStateByButton = async (interaction: ButtonInteraction, isCurrentlyReady: boolean) => {
+    console.log('switchReadyState start');
 
-    if (!interaction.customId.startsWith('ready-lt-')) {
+    const currentButton = isCurrentlyReady ? unreadyLTButton : readyLTButton;
+    const newButton = isCurrentlyReady ? readyLTButton : unreadyLTButton;
+
+    if (!currentButton.isThisButton(interaction)) {
         console.error('ltId is empty');
-        await interaction.editReply({ content: 'Failed to ready LT' });
+        await interaction.editReply({ content: 'Failed to switch ready state' });
         return;
     }
 
     const ltId = parseInt(interaction.customId.split('-')[2]);
 
-    const { lt, error } = await updateLTStateById(ltId, 'READY');
+    const { lt, error } = await updateLTStateById(ltId, isCurrentlyReady ? 'UNREADY' : 'READY');
 
-    // ltが取得できている場合は変更が成功しているとみなす => 既にREADYの場合も成功扱い
+    // ltが取得できている場合は変更が成功しているとみなす
+    // => 変更が無かったときもltが取得できるため、成功扱いとする
     if (lt) {
         const newComponents = interaction.message.components.map((row) => {
             return new ActionRowBuilder<ButtonBuilder>().addComponents(
                 row.components.map((component) => {
-                    if (component.customId?.startsWith('ready-lt-')) {
-                        return unreadyLTButton.create(lt.id.toString());
+                    if (component.customId === interaction.customId) {
+                        return newButton.create(lt.id.toString());
                     }
                     return component;
                 }) as ButtonBuilder[]
             );
         });
 
-        const newContent = interaction.message.content.replace('準備中', '発表可能');
+        const newContent = interaction.message.content.replace(isCurrentlyReady ? '発表可能' : '準備中', isCurrentlyReady ? '準備中' : '発表可能');
 
         await interaction.editReply({ content: newContent, components: newComponents });
     } else {
         console.error('update error', error);
-        await interaction.editReply({ content: 'Failed to ready LT' });
+        await interaction.editReply({ content: 'Failed to switch ready state' });
     }
-}
-
-export const changeToUnreadyLTByButton = async (interaction: ButtonInteraction) => {
-    console.log('unreadyLTByButton start');
-
-    if (!interaction.customId.startsWith('unready-lt-')) {
-        console.error('ltId is empty');
-        await interaction.editReply({ content: 'Failed to unready LT' });
-        return;
-    }
-
-    const ltId = parseInt(interaction.customId.split('-')[2]);
-
-    const { lt, error } = await updateLTStateById(ltId, 'UNREADY');
-
-    // ltが取得できている場合は変更が成功しているとみなす => 既にUNREADYの場合も成功扱い
-    if (lt) {
-        const newComponents = interaction.message.components.map((row) => {
-            return new ActionRowBuilder<ButtonBuilder>().addComponents(
-                row.components.map((component) => {
-                    if (component.customId?.startsWith('unready-lt-')) {
-                        return readyLTButton.create(lt.id.toString());
-                    }
-                    return component;
-                }) as ButtonBuilder[]
-            );
-        });
-
-        const newContent = interaction.message.content.replace('発表可能', '準備中');
-
-        await interaction.editReply({ content: newContent, components: newComponents });
-    } else {
-        console.error('update error', error);
-        await interaction.editReply({ content: 'Failed to unready LT' });
-    }
+    console.log('switchReadyState end');
 }

--- a/src/services/LTNotificationService.ts
+++ b/src/services/LTNotificationService.ts
@@ -1,7 +1,6 @@
 import { roleMention, userMention, type Client, type TextChannel } from "discord.js";
 import type { LightningTalk } from "@prisma/client";
-import { deleteNotificationMessage, insertNotificationMessage } from "../tables/notificationMessageTable";
-import { map } from "zod";
+import { insertNotificationMessage } from "../tables/notificationMessageTable";
 
 const { NOTIFICATION_CHANNEL_ID, ROLE_ID } = process.env;
 

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -76,3 +76,55 @@ export const getLTById = async (id: number): Promise<{ lt: LightningTalk | null,
         console.log('end getLTById');
     }
 }
+
+/**
+ * 以下の変更のみ許容する
+ * - UNREADY <-> READY
+ * - READY -> DOING
+ * - DOING -> DONE
+*/
+export const updateLTStateById = async (id: number, state: State): Promise<{ lt: LightningTalk | null, error: any }> => {
+    console.log('start updateStateById');
+
+    const {lt: targetLT, error} = await getLTById(id);
+    if (error || !targetLT) {
+        console.error('get error', error);
+        return { lt: null, error };
+    }
+
+    const validTransitions: Record<State, State[]> = {
+        UNREADY: ['READY'],
+        READY: ['UNREADY', 'DOING'],
+        DOING: ['DONE'],
+        DONE: []
+    };
+
+    if (!validTransitions[targetLT.state].includes(state)) {
+        const error = `Invalid state transition from ${targetLT.state} to ${state}`;
+        console.error(error);
+        return { lt: null, error };
+    }
+
+
+
+    const prisma = new PrismaClient();
+
+    try {
+        const lt = await prisma.lightningTalk.update({
+            where: {
+                id
+            },
+            data: {
+                state
+            }
+        });
+        console.log('updateStateById', lt);
+        return { lt, error: null };
+    } catch (error: any) {
+        console.error('Failed to updateStateById', error);
+        return { lt: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end updateStateById');
+    }
+}

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -50,3 +50,29 @@ export const deleteLTById = async (id: number): Promise<{ lt: LightningTalk | nu
         console.log('end deleteLTById');
     }
 }
+
+
+export const getLTById = async (id: number): Promise<{ lt: LightningTalk | null, error: any }> => {
+    console.log('start getLTById');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const lt = await prisma.lightningTalk.findUnique({
+            where: {
+                id
+            }
+        });
+        console.log('getLTById', lt);
+        if (!lt) {
+            return { lt: null, error: 'LT not found' };
+        }
+        return { lt, error: null };
+    } catch (error: any) {
+        console.error('Failed to getLTById', error);
+        return { lt: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end getLTById');
+    }
+}

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -86,10 +86,16 @@ export const getLTById = async (id: number): Promise<{ lt: LightningTalk | null,
 export const updateLTStateById = async (id: number, state: State): Promise<{ lt: LightningTalk | null, error: any }> => {
     console.log('start updateStateById');
 
-    const {lt: targetLT, error} = await getLTById(id);
+    const { lt: targetLT, error } = await getLTById(id);
+
     if (error || !targetLT) {
         console.error('get error', error);
         return { lt: null, error };
+    }
+
+    if (targetLT.state === state) {
+        console.error('currentState and newState are the same');
+        return { lt: targetLT, error: 'currentState and newState are the same' };
     }
 
     const validTransitions: Record<State, State[]> = {


### PR DESCRIPTION
以下のように、LT登録コマンド実行時の返信に状態変更ボタンを載せ、押すと切り替わるように実装

![image](https://github.com/user-attachments/assets/79e7565a-80bf-4de4-bd91-c657d8e0e651)
![image](https://github.com/user-attachments/assets/4fe8ff9d-78a1-42f2-b38a-d540dfe5abdf)

DBとDiscord上の状態は非同期であるため、（現状はあり得ないが）既に変更がなされているのに、ボタンが元のままである、つまりボタンを押しても変更がない状態がありうる。
そのため、ボタンを押した時に既にその状態であった時は、特にエラーは表示せずに変更がなされた体で動作するよう実装した。

また、状態変更にバリデーションを掛け、UNREADY⇆READY→DOING→DONEという遷移制約を掛けた。
ただ、DOING、DONE時にボタンを押した時のエラーハンドリングは、まだ未確認（一応壊れないようにはしているつもり）
この辺りはDOING、DONEの値が入るような実装をしたときに改めてチェックする。

### LTの状態管理のための新しいボタン：
* [`src/buttons/index.ts`](diffhunk://#diff-d0d1535108ebd19412a17b3bd9a6c8d29e246edf01786efd4dce23855792d8b4R3-R10): ボタンのリストに `readyLTButton` と `unreadyLTButton` を追加した。
* [`src/buttons/readyLTButton.ts`](diffhunk://#diff-c9220581e1a11e2d3cdc802853f3be514ac085ec88f6f18428d7615ad3e8f678R1-R19): LTが準備完了であることを示すための `readyLTButton` を実装した。
* [`src/buttons/unreadyLTButtons.ts`](diffhunk://#diff-d7ed810242141e5015621783d06066e397332b5d4d3ada3d80eaedee39eb4e0bR1-R19): LTが未準備であることを示すための `unreadyLTButton` を実装した。

### LT 管理サービスの更新:
* [`src/services/LTManagementService.ts`](diffhunk://#diff-06b99e162310f94f0f59af6427cace637834a81b91db962205c88676a4eaf69bL2-R7): 準備完了または未準備のボタンがクリックされた際の状態変更を処理する `switchLTReadyStateByButton` 関数を追加した。新しいボタンを含めるために `registerLTByCommand` を更新した。 [[1]](diffhunk://#diff-06b99e162310f94f0f59af6427cace637834a81b91db962205c88676a4eaf69bL2-R7)  [[2]](diffhunk://#diff-06b99e162310f94f0f59af6427cace637834a81b91db962205c88676a4eaf69bL33-R36)  [[3]](diffhunk://#diff-06b99e162310f94f0f59af6427cace637834a81b91db962205c88676a4eaf69bR82-R122)

### LTテーブルの更新:
* [`src/tables/lightningTalkTable.ts`](diffhunk://#diff-3583c66008e0d94dd4c0e8b1066202e00319287fdccc2d82b592eed8bded287cR53-R136): LTの状態を取得する関数 `getLTById` と、LTの状態を更新する関数 `updateLTStateById` をそれぞれ追加した。