### PR TITLE
LT開始から終了までの進行を実装

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model LightningTalk {
   updatedAt   DateTime @updatedAt @map("updated_at")
 
   notificationMessage NotificationMessage?
+  nextLightningTalk   NextLightningTalk?
 
   @@map("lightning_talks")
 }
@@ -38,6 +39,18 @@ model NotificationMessage {
   messageId       String        @unique @map("message_id")
   lightningTalk   LightningTalk @relation(fields: [lightningTalkId], references: [id], onDelete: Cascade)
   lightningTalkId Int           @unique @map("lightning_talk_id")
+  createdAt       DateTime      @default(now()) @map("created_at")
+  updatedAt       DateTime      @updatedAt @map("updated_at")
 
   @@map("notification_messages")
+}
+
+model NextLightningTalk {
+  id              Int           @id @default(autoincrement())
+  lightningTalk   LightningTalk @relation(fields: [lightningTalkId], references: [id], onDelete: Cascade)
+  lightningTalkId Int           @unique @map("lightning_talk_id")
+  createdAt       DateTime      @default(now()) @map("created_at")
+  updatedAt       DateTime      @updatedAt @map("updated_at")
+
+  @@map("next_lightning_talks")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model NextLightningTalk {
   id              Int           @id @default(autoincrement())
   lightningTalk   LightningTalk @relation(fields: [lightningTalkId], references: [id], onDelete: Cascade)
   lightningTalkId Int           @unique @map("lightning_talk_id")
+  order           Int           @unique
   createdAt       DateTime      @default(now()) @map("created_at")
   updatedAt       DateTime      @updatedAt @map("updated_at")
 

--- a/src/buttons/index.ts
+++ b/src/buttons/index.ts
@@ -1,5 +1,6 @@
 import type { Button } from '../types';
 import { deleteLTButton } from './deleteLTButton';
+import { moveNextLTButton } from './moveNextLTButton';
 import { readyLTButton } from './readyLTButton';
 import { unreadyLTButton } from './unreadyLTButtons';
 
@@ -7,7 +8,8 @@ import { unreadyLTButton } from './unreadyLTButtons';
 const buttons: Button[] = [
     deleteLTButton,
     readyLTButton,
-    unreadyLTButton
+    unreadyLTButton,
+    moveNextLTButton,
 ];
 
 export default buttons;

--- a/src/buttons/moveNextLTButton.ts
+++ b/src/buttons/moveNextLTButton.ts
@@ -1,5 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from "discord.js";
 import type { Button } from "../types";
+import { moveNextLT } from "../services/LTNotificationService";
 
 export const moveNextLTButton: Button = {
     create: () => {
@@ -13,5 +14,6 @@ export const moveNextLTButton: Button = {
     },
     onClick: async (interaction) => {
         await interaction.deferUpdate();
+        await moveNextLT(interaction.client);
     }
 }

--- a/src/buttons/moveNextLTButton.ts
+++ b/src/buttons/moveNextLTButton.ts
@@ -1,0 +1,17 @@
+import { ButtonBuilder, ButtonStyle } from "discord.js";
+import type { Button } from "../types";
+
+export const moveNextLTButton: Button = {
+    create: () => {
+        return new ButtonBuilder()
+            .setCustomId('move-next-lt')
+            .setLabel('次のLTへ')
+            .setStyle(ButtonStyle.Primary)
+    },
+    isThisButton: (interaction) => {
+        return interaction.customId === 'move-next-lt';
+    },
+    onClick: async (interaction) => {
+        await interaction.deferUpdate();
+    }
+}

--- a/src/buttons/moveNextLTButton.ts
+++ b/src/buttons/moveNextLTButton.ts
@@ -1,18 +1,24 @@
-import { ButtonBuilder, ButtonStyle } from "discord.js";
+import { ButtonBuilder, ButtonStyle, MessageFlags } from "discord.js";
 import type { Button } from "../types";
 import { moveNextLT } from "../services/LTNotificationService";
+
+const { ADMIN_USER_ID } = process.env;
 
 export const moveNextLTButton: Button = {
     create: () => {
         return new ButtonBuilder()
             .setCustomId('move-next-lt')
-            .setLabel('次のLTへ')
+            .setLabel('次のLTへ（LT会管理者のみ実行可能）')
             .setStyle(ButtonStyle.Primary)
     },
     isThisButton: (interaction) => {
         return interaction.customId === 'move-next-lt';
     },
     onClick: async (interaction) => {
+        if (interaction.user.id !== ADMIN_USER_ID) {
+            await interaction.reply({ content: 'このコマンドは特定の管理者のみ実行可能です。', flags: MessageFlags.Ephemeral });
+            return;
+        }
         await interaction.deferUpdate();
         await moveNextLT(interaction.client);
     }

--- a/src/buttons/moveNextLTButton.ts
+++ b/src/buttons/moveNextLTButton.ts
@@ -21,5 +21,6 @@ export const moveNextLTButton: Button = {
         }
         await interaction.deferUpdate();
         await moveNextLT(interaction.client);
+        await interaction.message.edit({ components: [] });
     }
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,10 +1,12 @@
 import type { Command } from '../types';
 import { notifyNextLTsCommand } from './notifyNextLTsCommand';
 import { registerLTCommand } from './registerLTCommand';
+import { startLTsCommand } from './startLTCommand';
 
 const commands: Command[] = [
     registerLTCommand,
     notifyNextLTsCommand,
+    startLTsCommand,
 ];
 
 export default commands;

--- a/src/commands/startLTCommand.ts
+++ b/src/commands/startLTCommand.ts
@@ -1,0 +1,23 @@
+import { MessageFlags } from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import type { Command } from '../types';
+
+const { ADMIN_USER_ID } = process.env;
+
+export const startLTsCommand: Command = {
+    data: new SlashCommandBuilder()
+        .setName('start-lts')
+        .setDescription('（LT会管理者のみ実行可能）LTを開始します。'),
+
+    isThisCommand: function (interaction) {
+        return interaction.commandName === this.data.name;
+    },
+
+    execute: async function (interaction) {
+        if (interaction.user.id !== ADMIN_USER_ID) {
+            await interaction.reply({ content: 'このコマンドは特定の管理者のみ実行可能です。', flags: MessageFlags.Ephemeral });
+            return;
+        }
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    }
+}

--- a/src/commands/startLTCommand.ts
+++ b/src/commands/startLTCommand.ts
@@ -1,6 +1,7 @@
 import { MessageFlags } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import type { Command } from '../types';
+import { startLTsByCommand } from '../services/LTNotificationService';
 
 const { ADMIN_USER_ID } = process.env;
 
@@ -19,5 +20,6 @@ export const startLTsCommand: Command = {
             return;
         }
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        await startLTsByCommand(interaction);
     }
 }

--- a/src/services/LTNotificationService.ts
+++ b/src/services/LTNotificationService.ts
@@ -2,6 +2,7 @@ import { CommandInteraction, roleMention, userMention, type Client, type TextCha
 import type { LightningTalk } from "@prisma/client";
 import { insertNotificationMessage } from "../tables/notificationMessageTable";
 import { getNextReadyLTs } from "../tables/lightningTalkTable";
+import { insertNextLTs } from "../tables/nextLightningTalkTable";
 
 const { NOTIFICATION_CHANNEL_ID, ROLE_ID } = process.env;
 
@@ -29,7 +30,7 @@ export const notifyLTRegistration = async (client: Client, lt: LightningTalk) =>
 }
 
 /* 完全に削除するのではなく、罫線を引いて削除したことを示す */
-export const deleteNotificationMessageById = async (client: Client, messageId:string) => {
+export const deleteNotificationMessageById = async (client: Client, messageId: string) => {
     console.log('start deleteNotificationMessageById');
 
     const channel = client.channels.cache.get(NOTIFICATION_CHANNEL_ID) as TextChannel;
@@ -48,7 +49,7 @@ export const notifyNextLTsByCommand = async (interaction: CommandInteraction) =>
     const limitOption = interaction.options.get('limit');
     const limit = limitOption ? limitOption.value as number : 10;
 
-    const {lts, error} = await getNextReadyLTs(limit);
+    const { lts, error } = await getNextReadyLTs(limit);
 
     if (error || !lts) {
         console.error('Failed to get LTs', error);
@@ -78,4 +79,47 @@ export const notifyNextLTsByCommand = async (interaction: CommandInteraction) =>
     await interaction.editReply({ content: '通知しました！' });
     console.log('end notifyNextLTs');
 }
+
+export const startLTsByCommand = async (interaction: CommandInteraction) => {
+    console.log('start startLTsByCommand');
+
+    const limit = interaction.options.get('limit')?.value as number || 10
+    const { lts, error: getNextLtsError } = await getNextReadyLTs(limit);
+
+    if (getNextLtsError || !lts) {
+        console.error('Failed to get LTs', getNextLtsError);
+        await interaction.editReply({ content: 'Failed to get LTs' });
+        return;
+    }
+
+    if (lts.length === 0) {
+        console.error('No LTs');
+        await interaction.editReply({ content: 'No LTs' });
+        return;
+    }
+
+    const { nextLTs, error: insertNextLTsError } = await insertNextLTs(lts.map((lt) => lt.id));
+
+    if (insertNextLTsError || !nextLTs) {
+        console.error('Failed to insert next LTs', insertNextLTsError);
+        await interaction.editReply({ content: 'Failed to start LT' });
+        return;
+    }
+
+    const notificationMessageContent = [
+        `${roleMention(ROLE_ID)}`,
+        `以下のLTセッションを開始します！`,
+        ...lts.map((lt) => `「${lt.title}」 発表者：${userMention(lt.speaker)}`),
+    ].join('\n');
+
+    const channel = interaction.client.channels.cache.get(NOTIFICATION_CHANNEL_ID) as TextChannel;
+    console.log('channel', channel.name);
+
+    const sendMessage = await channel?.send(notificationMessageContent);
+    console.log('sendMessage', sendMessage.content);
+
+    await interaction.editReply({ content: 'LTを開始しました！' });
+    console.log('end startLTsByCommand');
+}
+
 

--- a/src/services/LTNotificationService.ts
+++ b/src/services/LTNotificationService.ts
@@ -1,8 +1,9 @@
-import { CommandInteraction, roleMention, userMention, type Client, type TextChannel } from "discord.js";
+import { ActionRowBuilder, ButtonBuilder, CommandInteraction, roleMention, userMention, type Client, type TextChannel } from "discord.js";
 import type { LightningTalk } from "@prisma/client";
 import { insertNotificationMessage } from "../tables/notificationMessageTable";
 import { getNextReadyLTs, updateLTStateById } from "../tables/lightningTalkTable";
-import { insertNextLTs } from "../tables/nextLightningTalkTable";
+import { deleteNextLT, getNextLT, insertNextLTs } from "../tables/nextLightningTalkTable";
+import { moveNextLTButton } from "../buttons/moveNextLTButton";
 
 const { NOTIFICATION_CHANNEL_ID, ROLE_ID } = process.env;
 
@@ -127,7 +128,69 @@ export const startLTsByCommand = async (interaction: CommandInteraction) => {
     const sendMessage = await channel?.send(notificationMessageContent);
     console.log('sendMessage', sendMessage.content);
 
+    await moveNextLT(interaction.client, true);
+
     await interaction.editReply({ content: 'LTを開始しました！' });
     console.log('end startLTsByCommand');
+}
+
+export const moveNextLT = async (client: Client, isFirst: boolean = false) => {
+    console.log('start moveNextLT');
+
+    if (!isFirst) {
+        const { nextLT: doneLT, error } = await getNextLT();
+
+        if (error || !doneLT) {
+            console.error('Failed to get next LT', error);
+            return;
+        }
+
+        const { lt: currentLT, error: updateCurrentLTError } = await updateLTStateById(doneLT.lightningTalk.id, 'DONE');
+
+        if (updateCurrentLTError || !currentLT) {
+            console.error('Failed to update current LT', updateCurrentLTError);
+            return;
+        }
+
+        const { error: deleteNextLTError } = await deleteNextLT(doneLT.id);
+
+        if (deleteNextLTError) {
+            console.error('Failed to delete next LT', deleteNextLTError);
+            return;
+        }
+    }
+
+    const { nextLT, error: getNextLTError } = await getNextLT();
+
+    if (getNextLTError !== 'No next lightning talk found' && (getNextLTError || !nextLT)) {
+        console.error('Failed to get next LT', getNextLTError);
+        return;
+    }
+
+    const channel = client.channels.cache.get(NOTIFICATION_CHANNEL_ID) as TextChannel;
+    console.log('channel', channel.name);
+
+    const notificationMessageContent =
+        nextLT ?
+            [
+                `${roleMention(ROLE_ID)}`,
+                `次のLTは以下の通りです！`,
+                `「${nextLT.lightningTalk.title}」 発表者：${userMention(nextLT.lightningTalk.speaker)}`,
+                nextLT.lightningTalk.description ? `概要：${nextLT.lightningTalk.description}` : '',
+            ].filter(Boolean).join('\n')
+            :
+            `${roleMention(ROLE_ID)}\nこのセッションにおける全てのLTが終了しました！`;
+
+    const row =
+        nextLT ?
+            new ActionRowBuilder<ButtonBuilder>()
+                .addComponents(moveNextLTButton.create())
+            :
+            null;
+
+    const sendMessage = await channel?.send({ content: notificationMessageContent, components: row ? [row] : [] });
+    console.log('sendMessage', sendMessage.content);
+
+    console.log('end moveNextLT');
 }
 

--- a/src/services/LTNotificationService.ts
+++ b/src/services/LTNotificationService.ts
@@ -1,7 +1,7 @@
 import { CommandInteraction, roleMention, userMention, type Client, type TextChannel } from "discord.js";
 import type { LightningTalk } from "@prisma/client";
 import { insertNotificationMessage } from "../tables/notificationMessageTable";
-import { getNextReadyLTs } from "../tables/lightningTalkTable";
+import { getNextReadyLTs, updateLTStateById } from "../tables/lightningTalkTable";
 import { insertNextLTs } from "../tables/nextLightningTalkTable";
 
 const { NOTIFICATION_CHANNEL_ID, ROLE_ID } = process.env;
@@ -106,6 +106,15 @@ export const startLTsByCommand = async (interaction: CommandInteraction) => {
         return;
     }
 
+    lts.map(async (lt) => {
+        const { lt: tmpLT, error } = await updateLTStateById(lt.id, 'DOING');
+        if (error || !tmpLT) {
+            console.error('Failed to update LT', error);
+            await interaction.editReply({ content: 'Failed to start LT' });
+            return;
+        }
+    });
+
     const notificationMessageContent = [
         `${roleMention(ROLE_ID)}`,
         `以下のLTセッションを開始します！`,
@@ -121,5 +130,4 @@ export const startLTsByCommand = async (interaction: CommandInteraction) => {
     await interaction.editReply({ content: 'LTを開始しました！' });
     console.log('end startLTsByCommand');
 }
-
 

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -1,4 +1,4 @@
-import { Prisma, PrismaClient, State, type LightningTalk } from "@prisma/client";
+import { PrismaClient, State, type LightningTalk } from "@prisma/client";
 
 export const insertLT = async (title: string, speaker: string, ready: boolean, description?: string): Promise<{ lt: LightningTalk | null, error: any }> => {
     console.log('start insertLT');

--- a/src/tables/nextLightningTalkTable.ts
+++ b/src/tables/nextLightningTalkTable.ts
@@ -2,9 +2,9 @@ import { type NextLightningTalk, PrismaClient } from "@prisma/client";
 
 
 export const insertNextLTs = async (lightningTalkIds: number[]): Promise<{ nextLTs: NextLightningTalk[] | null, error: any }> => {
-
     console.log('start insertNextLTs');
 
+    await deleteAllNextLTs();
     const prisma = new PrismaClient();
 
     try {
@@ -28,22 +28,22 @@ export const insertNextLTs = async (lightningTalkIds: number[]): Promise<{ nextL
     }
 }
 
-
-export const getAllNextLTs = async (): Promise<{ nextLTs: NextLightningTalk[] | null, error: any }> => {
-    console.log('start getAllNextLTs');
+const deleteAllNextLTs = async (): Promise<{ count: number | null, error: any }> => {
+    console.log('start deleteAllNextLTs');
 
     const prisma = new PrismaClient();
 
     try {
-        const nextLTs: NextLightningTalk[] = await prisma.nextLightningTalk.findMany();
-        console.log('getAllNextLTs', nextLTs);
+        const result = await prisma.nextLightningTalk.deleteMany();
+        console.log('deleteAllNextLTs', result);
 
-        return { nextLTs, error: null };
+        return { count: result.count, error: null };
     } catch (error: any) {
-        console.error('Failed to getAllNextLTs', error);
-        return { nextLTs: null, error };
+        console.error('Failed to deleteAllNextLTs', error);
+        return { count: null, error };
     } finally {
         await prisma.$disconnect();
-        console.log('end getAllNextLTs');
+        console.log('end deleteAllNextLTs');
     }
 }
+

--- a/src/tables/nextLightningTalkTable.ts
+++ b/src/tables/nextLightningTalkTable.ts
@@ -47,3 +47,49 @@ const deleteAllNextLTs = async (): Promise<{ count: number | null, error: any }>
     }
 }
 
+export const getNextLT = async (): Promise<{ nextLT: NextLightningTalk | null, error: any }> => {
+    console.log('start getNextLT');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const nextLT: NextLightningTalk | null = await prisma.nextLightningTalk.findFirst();
+        if (!nextLT) {
+            console.log('No next lightning talk found');
+            return { nextLT: null, error: 'No next lightning talk found' };
+        }
+        console.log('getNextLT', nextLT);
+
+        return { nextLT, error: null };
+    } catch (error: any) {
+        console.error('Failed to getNextLT', error);
+        return { nextLT: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end getNextLT');
+    }
+}
+
+
+export const deleteFirstNextLT = async (nextLTId: number): Promise<{ nextLT: NextLightningTalk | null, error: any }> => {
+    console.log('start deleteFirstNextLT');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const nextLT: NextLightningTalk = await prisma.nextLightningTalk.delete({
+            where: {
+                id: nextLTId
+            }
+        });
+        console.log('deleteFirstNextLT', nextLT);
+
+        return { nextLT, error: null };
+    } catch (error: any) {
+        console.error('Failed to deleteFirstNextLT', error);
+        return { nextLT: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end deleteFirstNextLT');
+    }
+}

--- a/src/tables/nextLightningTalkTable.ts
+++ b/src/tables/nextLightningTalkTable.ts
@@ -1,4 +1,5 @@
 import { type NextLightningTalk, PrismaClient } from "@prisma/client";
+import type { NextLightningTalkWithDetails } from "../types";
 
 
 export const insertNextLTs = async (lightningTalkIds: number[]): Promise<{ nextLTs: NextLightningTalk[] | null, error: any }> => {
@@ -47,13 +48,23 @@ const deleteAllNextLTs = async (): Promise<{ count: number | null, error: any }>
     }
 }
 
-export const getNextLT = async (): Promise<{ nextLT: NextLightningTalk | null, error: any }> => {
+export const getNextLT = async (): Promise<{ nextLT: NextLightningTalkWithDetails | null, error: any }> => {
     console.log('start getNextLT');
 
     const prisma = new PrismaClient();
 
     try {
-        const nextLT: NextLightningTalk | null = await prisma.nextLightningTalk.findFirst();
+        const nextLT: NextLightningTalkWithDetails | null = await prisma.nextLightningTalk.findFirst({
+            include: {
+                lightningTalk: {
+                    select: {
+                        title: true,
+                        speaker: true,
+                        description: true
+                    }
+                }
+            }
+        });
         if (!nextLT) {
             console.log('No next lightning talk found');
             return { nextLT: null, error: 'No next lightning talk found' };
@@ -70,9 +81,8 @@ export const getNextLT = async (): Promise<{ nextLT: NextLightningTalk | null, e
     }
 }
 
-
-export const deleteFirstNextLT = async (nextLTId: number): Promise<{ nextLT: NextLightningTalk | null, error: any }> => {
-    console.log('start deleteFirstNextLT');
+export const deleteNextLT = async (nextLTId: number): Promise<{ nextLT: NextLightningTalk | null, error: any }> => {
+    console.log('start deleteNextLT');
 
     const prisma = new PrismaClient();
 
@@ -82,14 +92,14 @@ export const deleteFirstNextLT = async (nextLTId: number): Promise<{ nextLT: Nex
                 id: nextLTId
             }
         });
-        console.log('deleteFirstNextLT', nextLT);
+        console.log('deleteNextLT', nextLT);
 
         return { nextLT, error: null };
     } catch (error: any) {
-        console.error('Failed to deleteFirstNextLT', error);
+        console.error('Failed to deleteNextLT', error);
         return { nextLT: null, error };
     } finally {
         await prisma.$disconnect();
-        console.log('end deleteFirstNextLT');
+        console.log('end deleteNextLT');
     }
 }

--- a/src/tables/nextLightningTalkTable.ts
+++ b/src/tables/nextLightningTalkTable.ts
@@ -1,0 +1,49 @@
+import { type NextLightningTalk, PrismaClient } from "@prisma/client";
+
+
+export const insertNextLTs = async (lightningTalkIds: number[]): Promise<{ nextLTs: NextLightningTalk[] | null, error: any }> => {
+
+    console.log('start insertNextLTs');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const nextLTs: NextLightningTalk[] = await Promise.all(lightningTalkIds.map(async (lightningTalkId) => {
+            const nextLT = await prisma.nextLightningTalk.create({
+                data: {
+                    lightningTalkId
+                }
+            });
+            return nextLT;
+        }));
+        console.log('insertNextLTs', nextLTs);
+
+        return { nextLTs, error: null };
+    } catch (error: any) {
+        console.error('Failed to insertNextLTs', error);
+        return { nextLTs: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end insertNextLTs');
+    }
+}
+
+
+export const getAllNextLTs = async (): Promise<{ nextLTs: NextLightningTalk[] | null, error: any }> => {
+    console.log('start getAllNextLTs');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const nextLTs: NextLightningTalk[] = await prisma.nextLightningTalk.findMany();
+        console.log('getAllNextLTs', nextLTs);
+
+        return { nextLTs, error: null };
+    } catch (error: any) {
+        console.error('Failed to getAllNextLTs', error);
+        return { nextLTs: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end getAllNextLTs');
+    }
+}

--- a/src/tables/nextLightningTalkTable.ts
+++ b/src/tables/nextLightningTalkTable.ts
@@ -58,6 +58,7 @@ export const getNextLT = async (): Promise<{ nextLT: NextLightningTalkWithDetail
             include: {
                 lightningTalk: {
                     select: {
+                        id: true,
                         title: true,
                         speaker: true,
                         description: true

--- a/src/tables/nextLightningTalkTable.ts
+++ b/src/tables/nextLightningTalkTable.ts
@@ -9,10 +9,11 @@ export const insertNextLTs = async (lightningTalkIds: number[]): Promise<{ nextL
     const prisma = new PrismaClient();
 
     try {
-        const nextLTs: NextLightningTalk[] = await Promise.all(lightningTalkIds.map(async (lightningTalkId) => {
+        const nextLTs: NextLightningTalk[] = await Promise.all(lightningTalkIds.map(async (lightningTalkId, index) => {
             const nextLT = await prisma.nextLightningTalk.create({
                 data: {
-                    lightningTalkId
+                    lightningTalkId,
+                    order: index
                 }
             });
             return nextLT;
@@ -64,6 +65,9 @@ export const getNextLT = async (): Promise<{ nextLT: NextLightningTalkWithDetail
                         description: true
                     }
                 }
+            },
+            orderBy: {
+                order: 'asc'
             }
         });
         if (!nextLT) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./command";
 export * from "./button";
+export * from "./table";
 

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -1,0 +1,9 @@
+import type { NextLightningTalk } from "@prisma/client";
+
+export type NextLightningTalkWithDetails = NextLightningTalk & {
+    lightningTalk: {
+        title: string;
+        speaker: string;
+        description: string;
+    };
+};

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -2,6 +2,7 @@ import type { NextLightningTalk } from "@prisma/client";
 
 export type NextLightningTalkWithDetails = NextLightningTalk & {
     lightningTalk: {
+        id: number;
         title: string;
         speaker: string;
         description: string;


### PR DESCRIPTION
### スキーマの変更:
* `prisma/schema.prisma` の `LightningTalk` モデルに `nextLightningTalk` リレーションを追加した。
* `id`, `lightningTalkId`, `order`, `createdAt`, および `updatedAt` のフィールドを持つ `NextLightningTalk` モデルを導入した。

### ボタンとコマンドの追加：
次のLTに移動するための新しいボタン `moveNextLTButton` を追加し、その作成、識別、クリック処理ロジックを `src/buttons/moveNextLTButton.ts` に含めた。
新しい `moveNextLTButton` を含めるために `src/buttons/index.ts` を更新した。
LTセッションを開始するための新しいコマンド `startLTsCommand` を追加し、その定義と実行ロジックを `src/commands/startLTCommand.ts` に含めた。
新しい `startLTsCommand` を含めるために `src/commands/index.ts` を更新した。

### サービスの更新：
LTセッションを開始する機能（`startLTsByCommand`）と次のLTに移る機能（`moveNextLT`）を追加するために、`LTNotificationService` を拡張した。
`src/tables/nextLightningTalkTable.ts` 内の次のLTの挿入、削除、取得を含む、`NextLightningTalk` テーブルとのやりとりを追加した。

### 型定義:
* `src/types/table.ts` に `NextLightningTalk` の詳細情報を表す新しい型 `NextLightningTalkWithDetails` を追加した。
* 新しいテーブル型をエクスポートするために `src/types/index.ts` を更新した。