### PR TITLE
登録したLTの状態を変更する

### DIFF
--- a/src/commands/editLTCommand.ts
+++ b/src/commands/editLTCommand.ts
@@ -1,6 +1,7 @@
-import { ActionRowBuilder, MessageFlags, StringSelectMenuBuilder, StringSelectMenuOptionBuilder } from 'discord.js';
+import { ActionRowBuilder, MessageFlags, StringSelectMenuBuilder } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import type { Command } from '../types';
+import { myLTsStringSelectMenu } from '../stringSelectMenus/myLTsStringSelectMenu';
 
 
 export const editLTCommand: Command = {
@@ -14,23 +15,7 @@ export const editLTCommand: Command = {
 
     execute: async function (interaction) {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        const select = new StringSelectMenuBuilder()
-            .setCustomId('starter')
-            .setPlaceholder('Make a selection!')
-            .addOptions(
-                new StringSelectMenuOptionBuilder()
-                    .setLabel('Bulbasaur')
-                    .setDescription('The dual-type Grass/Poison Seed Pokémon.')
-                    .setValue('bulbasaur'),
-                new StringSelectMenuOptionBuilder()
-                    .setLabel('Charmander')
-                    .setDescription('The Fire-type Lizard Pokémon.')
-                    .setValue('charmander'),
-                new StringSelectMenuOptionBuilder()
-                    .setLabel('Squirtle')
-                    .setDescription('The Water-type Tiny Turtle Pokémon.')
-                    .setValue('squirtle'),
-            );
+        const select = myLTsStringSelectMenu.create(interaction.user.id);
 
         const row = new ActionRowBuilder<StringSelectMenuBuilder>()
             .addComponents(select);

--- a/src/commands/editLTCommand.ts
+++ b/src/commands/editLTCommand.ts
@@ -15,7 +15,11 @@ export const editLTCommand: Command = {
 
     execute: async function (interaction) {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        const select = myLTsStringSelectMenu.create(interaction.user.id);
+        const select = await myLTsStringSelectMenu.create(interaction.user.id);
+        if (!select) {
+            await interaction.editReply('Failed to get your LTs');
+            return;
+        }
 
         const row = new ActionRowBuilder<StringSelectMenuBuilder>()
             .addComponents(select);

--- a/src/commands/editLTCommand.ts
+++ b/src/commands/editLTCommand.ts
@@ -1,7 +1,7 @@
 import { ActionRowBuilder, MessageFlags, StringSelectMenuBuilder } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import type { Command } from '../types';
-import { myLTsStringSelectMenu } from '../stringSelectMenus/myLTsStringSelectMenu';
+import { editLTsStringSelectMenu } from '../stringSelectMenus/editLTsStringSelectMenu';
 
 
 export const editLTCommand: Command = {
@@ -15,7 +15,7 @@ export const editLTCommand: Command = {
 
     execute: async function (interaction) {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        const select = await myLTsStringSelectMenu.create(interaction.user.id);
+        const select = await editLTsStringSelectMenu.create(interaction.user.id);
         if (!select) {
             await interaction.editReply('Failed to get your LTs');
             return;

--- a/src/commands/editLTCommand.ts
+++ b/src/commands/editLTCommand.ts
@@ -1,0 +1,43 @@
+import { ActionRowBuilder, MessageFlags, StringSelectMenuBuilder, StringSelectMenuOptionBuilder } from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import type { Command } from '../types';
+
+
+export const editLTCommand: Command = {
+    data: new SlashCommandBuilder()
+        .setName('edit-lt')
+        .setDescription('自分のLTを編集します。'),
+
+    isThisCommand: function (interaction) {
+        return interaction.commandName === this.data.name;
+    },
+
+    execute: async function (interaction) {
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        const select = new StringSelectMenuBuilder()
+            .setCustomId('starter')
+            .setPlaceholder('Make a selection!')
+            .addOptions(
+                new StringSelectMenuOptionBuilder()
+                    .setLabel('Bulbasaur')
+                    .setDescription('The dual-type Grass/Poison Seed Pokémon.')
+                    .setValue('bulbasaur'),
+                new StringSelectMenuOptionBuilder()
+                    .setLabel('Charmander')
+                    .setDescription('The Fire-type Lizard Pokémon.')
+                    .setValue('charmander'),
+                new StringSelectMenuOptionBuilder()
+                    .setLabel('Squirtle')
+                    .setDescription('The Water-type Tiny Turtle Pokémon.')
+                    .setValue('squirtle'),
+            );
+
+        const row = new ActionRowBuilder<StringSelectMenuBuilder>()
+            .addComponents(select);
+
+        await interaction.editReply({
+            content: 'Choose your starter!',
+            components: [row],
+        });
+    }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,11 +2,13 @@ import type { Command } from '../types';
 import { notifyNextLTsCommand } from './notifyNextLTsCommand';
 import { registerLTCommand } from './registerLTCommand';
 import { startLTsCommand } from './startLTCommand';
+import { editLTCommand } from './editLTCommand';
 
 const commands: Command[] = [
     registerLTCommand,
     notifyNextLTsCommand,
     startLTsCommand,
+    editLTCommand,
 ];
 
 export default commands;

--- a/src/eventHandlers/interactionCreateHandler.ts
+++ b/src/eventHandlers/interactionCreateHandler.ts
@@ -1,6 +1,7 @@
 import { MessageFlags, type Interaction } from "discord.js";
 import commands from "../commands";
 import buttons from "../buttons";
+import stringSelectMenus from "../stringSelectMenus";
 
 export const interactionCreateHandler = async (interaction: Interaction) => {
     console.log('interactionCreateHandler start');
@@ -31,6 +32,21 @@ export const interactionCreateHandler = async (interaction: Interaction) => {
             }
         } else {
             await interaction.editReply({ content: interaction.message.content + '\nUnknown button.' });
+        }
+    } else if (interaction.isStringSelectMenu()) {
+        console.log(stringSelectMenus);
+        const stringSelectMenu = stringSelectMenus.find(selectMenu => selectMenu.isThisSelectMenu(interaction));
+
+        if (stringSelectMenu) {
+            try {
+                await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+                await stringSelectMenu.onSelect(interaction);
+            } catch (error) {
+                console.error('Failed to execute select menu', error);
+                await interaction.editReply({ content: interaction.message.content + '\nFailed to execute select menu.' });
+            }
+        } else {
+            await interaction.reply({ content: interaction.message.content + '\nUnknown select menu.' });
         }
     }
 

--- a/src/services/LTManagementService.ts
+++ b/src/services/LTManagementService.ts
@@ -36,14 +36,9 @@ export const handleLTRegistration = async (client: Client, title: string, ready:
 
     await notifyLTRegistration(client, lt);
 
-    const row = new ActionRowBuilder<ButtonBuilder>()
-        .addComponents(deleteLTButton.create(lt.id.toString()))
-        .addComponents(ready ? unreadyLTButton.create(lt.id.toString()) : readyLTButton.create(lt.id.toString()));
-
     console.log('registerLTByCommand end');
     return {
         content: `以下のLTを登録しました！\n 「${lt.title}」（${(ready ? '発表可能' : '準備中')}）${lt.description && "\n 概要: " + lt.description}`,
-        components: [row],
     };
 }
 

--- a/src/stringSelectMenus/editLTsStringSelectMenu.ts
+++ b/src/stringSelectMenus/editLTsStringSelectMenu.ts
@@ -46,11 +46,11 @@ export const editLTsStringSelectMenu: StringSelectMenu = {
             return;
         }
 
-        const ltInfoString = `タイトル: ${lt.title}\n状態: ${lt.state === "READY" ? "準備中" : "終了"}\n説明: ${lt.description}`;
+        const ltInfoString = `タイトル: ${lt.title}\n状態: ${lt.state === "READY" ? "準備中" : "発表可能"}\n説明: ${lt.description}`;
 
         const row = new ActionRowBuilder<ButtonBuilder>()
             .addComponents(deleteLTButton.create(lt.id.toString()))
-            .addComponents(lt.state === "READY" ? unreadyLTButton.create(lt.id.toString()) : readyLTButton.create(lt.id.toString()));
+            .addComponents(lt.state === "UNREADY" ? unreadyLTButton.create(lt.id.toString()) : readyLTButton.create(lt.id.toString()));
 
         await interaction.editReply({
             content: ltInfoString,

--- a/src/stringSelectMenus/editLTsStringSelectMenu.ts
+++ b/src/stringSelectMenus/editLTsStringSelectMenu.ts
@@ -1,6 +1,9 @@
-import { StringSelectMenuBuilder, StringSelectMenuOptionBuilder, type RestOrArray } from "discord.js";
+import { ActionRowBuilder, ButtonBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, type RestOrArray } from "discord.js";
 import type { StringSelectMenu } from "../types";
-import { getLTsBySpeaker } from "../tables/lightningTalkTable";
+import { getLTById, getLTsBySpeaker } from "../tables/lightningTalkTable";
+import { deleteLTButton } from "../buttons/deleteLTButton";
+import { readyLTButton } from "../buttons/readyLTButton";
+import { unreadyLTButton } from "../buttons/unreadyLTButtons";
 
 
 export const editLTsStringSelectMenu: StringSelectMenu = {
@@ -34,7 +37,25 @@ export const editLTsStringSelectMenu: StringSelectMenu = {
     },
 
     onSelect: async (interaction) => {
-        console.log(interaction.values);
-        await interaction.editReply('編集するLTを選択しました: ' + interaction.values[0]);
+        const ltId = interaction.values[0];
+        console.log('Selected LT', ltId);
+
+        const { lt, error } = await getLTById(parseInt(ltId));
+        if (error || !lt) {
+            console.error('Failed to get LT by ID', error);
+            return;
+        }
+
+        const ltInfoString = `タイトル: ${lt.title}\n状態: ${lt.state === "READY" ? "準備中" : "終了"}\n説明: ${lt.description}`;
+
+        const row = new ActionRowBuilder<ButtonBuilder>()
+            .addComponents(deleteLTButton.create(lt.id.toString()))
+            .addComponents(lt.state === "READY" ? unreadyLTButton.create(lt.id.toString()) : readyLTButton.create(lt.id.toString()));
+
+        await interaction.editReply({
+            content: ltInfoString,
+            components: [row],
+        });
+
     }
 }

--- a/src/stringSelectMenus/editLTsStringSelectMenu.ts
+++ b/src/stringSelectMenus/editLTsStringSelectMenu.ts
@@ -3,7 +3,7 @@ import type { StringSelectMenu } from "../types";
 import { getLTsBySpeaker } from "../tables/lightningTalkTable";
 
 
-export const myLTsStringSelectMenu: StringSelectMenu = {
+export const editLTsStringSelectMenu: StringSelectMenu = {
     create: async (discordUserId: string) => {
         const { lts, error } = await getLTsBySpeaker(discordUserId);
         if (error) {
@@ -34,7 +34,7 @@ export const myLTsStringSelectMenu: StringSelectMenu = {
     },
 
     onSelect: async (interaction) => {
-        await interaction.deferReply();
-        await interaction.editReply('You selected ' + interaction.values[0]);
+        console.log(interaction.values);
+        await interaction.editReply('編集するLTを選択しました: ' + interaction.values[0]);
     }
 }

--- a/src/stringSelectMenus/index.ts
+++ b/src/stringSelectMenus/index.ts
@@ -1,0 +1,8 @@
+import type { StringSelectMenu } from "../types";
+import { myLTsStringSelectMenu } from "./myLTsStringSelectMenu"
+
+const stringSelectMenus : StringSelectMenu[] = [
+    myLTsStringSelectMenu,
+];
+
+export default stringSelectMenus;

--- a/src/stringSelectMenus/index.ts
+++ b/src/stringSelectMenus/index.ts
@@ -1,8 +1,8 @@
 import type { StringSelectMenu } from "../types";
-import { myLTsStringSelectMenu } from "./myLTsStringSelectMenu"
+import { editLTsStringSelectMenu } from "./editLTsStringSelectMenu"
 
 const stringSelectMenus : StringSelectMenu[] = [
-    myLTsStringSelectMenu,
+    editLTsStringSelectMenu,
 ];
 
 export default stringSelectMenus;

--- a/src/stringSelectMenus/myLTsStringSelectMenu.ts
+++ b/src/stringSelectMenus/myLTsStringSelectMenu.ts
@@ -1,0 +1,35 @@
+import { StringSelectMenuBuilder, StringSelectMenuOptionBuilder } from "discord.js";
+import type { StringSelectMenu } from "../types";
+
+
+export const myLTsStringSelectMenu: StringSelectMenu = {
+    create: (discordUserId: string): StringSelectMenuBuilder => {
+        return new StringSelectMenuBuilder()
+            .setCustomId(`my-lts-${discordUserId}`)
+            .setPlaceholder('Make a selection!')
+            .addOptions(
+                new StringSelectMenuOptionBuilder()
+                    .setLabel('Bulbasaur')
+                    .setDescription('The dual-type Grass/Poison Seed Pokémon.')
+                    .setValue('bulbasaur'),
+                new StringSelectMenuOptionBuilder()
+                    .setLabel('Charmander')
+                    .setDescription('The Fire-type Lizard Pokémon.')
+                    .setValue('charmander'),
+                new StringSelectMenuOptionBuilder()
+                    .setLabel('Squirtle')
+                    .setDescription('The Water-type Tiny Turtle Pokémon.')
+                    .setValue('squirtle'),
+            );
+    },
+
+    isThisSelectMenu: (interaction) => {
+        console.log('isThisSelectMenu', interaction.customId);
+        return interaction.customId.startsWith('my-lts-');
+    },
+
+    onSelect: async (interaction) => {
+        await interaction.deferReply();
+        await interaction.editReply('You selected ' + interaction.values[0]);
+    }
+}

--- a/src/stringSelectMenus/myLTsStringSelectMenu.ts
+++ b/src/stringSelectMenus/myLTsStringSelectMenu.ts
@@ -1,25 +1,30 @@
-import { StringSelectMenuBuilder, StringSelectMenuOptionBuilder } from "discord.js";
+import { StringSelectMenuBuilder, StringSelectMenuOptionBuilder, type RestOrArray } from "discord.js";
 import type { StringSelectMenu } from "../types";
+import { getLTsBySpeaker } from "../tables/lightningTalkTable";
 
 
 export const myLTsStringSelectMenu: StringSelectMenu = {
-    create: (discordUserId: string): StringSelectMenuBuilder => {
+    create: async (discordUserId: string) => {
+        const { lts, error } = await getLTsBySpeaker(discordUserId);
+        if (error) {
+            console.error('Failed to get LTs by speaker', error);
+            return null;
+        }
+
+        if (!lts) {
+            console.error('LTs not found');
+            return null;
+        }
+
         return new StringSelectMenuBuilder()
             .setCustomId(`my-lts-${discordUserId}`)
-            .setPlaceholder('Make a selection!')
+            .setPlaceholder('編集したいLTを選択してください')
             .addOptions(
-                new StringSelectMenuOptionBuilder()
-                    .setLabel('Bulbasaur')
-                    .setDescription('The dual-type Grass/Poison Seed Pokémon.')
-                    .setValue('bulbasaur'),
-                new StringSelectMenuOptionBuilder()
-                    .setLabel('Charmander')
-                    .setDescription('The Fire-type Lizard Pokémon.')
-                    .setValue('charmander'),
-                new StringSelectMenuOptionBuilder()
-                    .setLabel('Squirtle')
-                    .setDescription('The Water-type Tiny Turtle Pokémon.')
-                    .setValue('squirtle'),
+                lts.map(lt => {
+                    return new StringSelectMenuOptionBuilder()
+                        .setLabel(lt.title)
+                        .setValue(lt.id.toString())
+                })
             );
     },
 

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -240,3 +240,31 @@ export const getNextReadyLTs = async (limit: number): Promise<{ lts: LightningTa
         console.log('end getNextLTsList');
     }
 }
+
+
+export const getLTsBySpeaker = async (speaker: string): Promise<{ lts: LightningTalk[] | null, error: any }> => {
+    console.log('start getLTsBySpeaker');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const lts = await prisma.lightningTalk.findMany({
+            where: {
+                speaker
+            }
+        });
+
+        console.log('getLTsBySpeaker', lts);
+
+        return { lts, error: null };
+
+    } catch (error: any) {
+        console.error('Failed to getLTsBySpeaker', error);
+        return { lts: null, error };
+
+    } finally {
+        await prisma.$disconnect();
+        console.log('end getLTsBySpeaker');
+    }
+}
+

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -242,7 +242,7 @@ export const getNextReadyLTs = async (limit: number): Promise<{ lts: LightningTa
 }
 
 
-export const getLTsBySpeaker = async (speaker: string): Promise<{ lts: LightningTalk[] | null, error: any }> => {
+export const getLTsBySpeaker = async (speaker: string, includeDone: boolean = false): Promise<{ lts: LightningTalk[] | null, error: any }> => {
     console.log('start getLTsBySpeaker');
 
     const prisma = new PrismaClient();
@@ -250,7 +250,12 @@ export const getLTsBySpeaker = async (speaker: string): Promise<{ lts: Lightning
     try {
         const lts = await prisma.lightningTalk.findMany({
             where: {
-                speaker
+                speaker,
+                state: includeDone ? {
+                    not: 'DOING'
+                } : {
+                    notIn: ['DONE', 'DOING']
+                }
             }
         });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
 export * from "./command";
 export * from "./button";
 export * from "./table";
-
+export * from "./selectMenu";

--- a/src/types/selectMenu.ts
+++ b/src/types/selectMenu.ts
@@ -1,7 +1,7 @@
-import type { AnySelectMenuInteraction, APISelectMenuComponent, BaseSelectMenuBuilder } from "discord.js";
+import type { StringSelectMenuInteraction, StringSelectMenuBuilder } from "discord.js";
 
-export type SelectMenu = {
-    create: (...args: any[]) => BaseSelectMenuBuilder<APISelectMenuComponent>;
-    isThisSelectMenu: (Interaction: AnySelectMenuInteraction) => boolean;
-    onSelect: (interaction: AnySelectMenuInteraction) => Promise<void>;
+export type StringSelectMenu = {
+    create: (...args: any[]) => StringSelectMenuBuilder;
+    isThisSelectMenu: (Interaction: StringSelectMenuInteraction) => boolean;
+    onSelect: (interaction: StringSelectMenuInteraction) => Promise<void>;
 };

--- a/src/types/selectMenu.ts
+++ b/src/types/selectMenu.ts
@@ -1,7 +1,7 @@
 import type { StringSelectMenuInteraction, StringSelectMenuBuilder } from "discord.js";
 
 export type StringSelectMenu = {
-    create: (...args: any[]) => StringSelectMenuBuilder;
-    isThisSelectMenu: (Interaction: StringSelectMenuInteraction) => boolean;
+    create: (...args: any[]) => StringSelectMenuBuilder | Promise<StringSelectMenuBuilder | null>;
+    isThisSelectMenu: (Interaction: StringSelectMenuInteraction) => boolean
     onSelect: (interaction: StringSelectMenuInteraction) => Promise<void>;
 };

--- a/src/types/selectMenu.ts
+++ b/src/types/selectMenu.ts
@@ -1,0 +1,7 @@
+import type { AnySelectMenuInteraction, APISelectMenuComponent, BaseSelectMenuBuilder } from "discord.js";
+
+export type SelectMenu = {
+    create: (...args: any[]) => BaseSelectMenuBuilder<APISelectMenuComponent>;
+    isThisSelectMenu: (Interaction: AnySelectMenuInteraction) => boolean;
+    onSelect: (interaction: AnySelectMenuInteraction) => Promise<void>;
+};


### PR DESCRIPTION
This pull request introduces a new feature to allow users to edit their Lightning Talks (LTs) in a Discord bot. The changes include adding a new command, handling string select menu interactions, and defining the necessary types and services.

New Feature: Edit Lightning Talks

* [`src/commands/editLTCommand.ts`](diffhunk://#diff-c6095d6fa31ae9e685396dd20afda5863da7e46281db591470c76274e6aa76c6R1-R32): Added a new command `editLTCommand` that allows users to edit their LTs using a string select menu.
* [`src/stringSelectMenus/editLTsStringSelectMenu.ts`](diffhunk://#diff-556a6fc4d25e31de45d76e456194d100ddcbaca5015bd4bd2161835a019978b0R1-R61): Created a new string select menu `editLTsStringSelectMenu` to list and select LTs for editing.

Integration and Interaction Handling:

* [`src/commands/index.ts`](diffhunk://#diff-a6a1db61476382a80351bf0b40126b3cfca87878293a3fca70dfe04367f4a11fR5-R11): Registered the new `editLTCommand` in the commands array.
* [`src/eventHandlers/interactionCreateHandler.ts`](diffhunk://#diff-6dccb6927bfda347493757520beb0cebc50368cd98dff8290e13cb363458e65cR4): Updated the interaction handler to process string select menu interactions. [[1]](diffhunk://#diff-6dccb6927bfda347493757520beb0cebc50368cd98dff8290e13cb363458e65cR4) [[2]](diffhunk://#diff-6dccb6927bfda347493757520beb0cebc50368cd98dff8290e13cb363458e65cR36-R50)
* [`src/stringSelectMenus/index.ts`](diffhunk://#diff-a02e0bd1deade312f41151992d3b7b31602fcf1ca8c66d1f3d0719e63b173adfR1-R8): Added the new string select menu to the array of available string select menus.

Type Definitions and Services:

* [`src/types/selectMenu.ts`](diffhunk://#diff-87123c9fcb38f3970ca6369387ca96cbac32617759002039f4fa9d6a81706ad5R1-R7): Defined a new type `StringSelectMenu` for handling string select menu interactions.
* [`src/tables/lightningTalkTable.ts`](diffhunk://#diff-3583c66008e0d94dd4c0e8b1066202e00319287fdccc2d82b592eed8bded287cR243-R275): Added a new service `getLTsBySpeaker` to fetch LTs by speaker from the database.