### PR TITLE
優先度の追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model LightningTalk {
   title       String
   description String   @default("")
   state       State    @default(UNREADY)
+  priority    Int      @default(0)
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 

--- a/src/buttons/index.ts
+++ b/src/buttons/index.ts
@@ -3,6 +3,7 @@ import { deleteLTButton } from './deleteLTButton';
 import { moveNextLTButton } from './moveNextLTButton';
 import { readyLTButton } from './readyLTButton';
 import { unreadyLTButton } from './unreadyLTButtons';
+import { MoveToFrontLTButton } from './moveToFrontLTButton';
 
 
 const buttons: Button[] = [
@@ -10,6 +11,7 @@ const buttons: Button[] = [
     readyLTButton,
     unreadyLTButton,
     moveNextLTButton,
+    MoveToFrontLTButton
 ];
 
 export default buttons;

--- a/src/buttons/moveToFrontLTButton.ts
+++ b/src/buttons/moveToFrontLTButton.ts
@@ -1,0 +1,34 @@
+import { ButtonBuilder, ButtonStyle } from "discord.js";
+import type { Button } from "../types";
+import { getMaxPriorityLT, updatePriority } from "../tables/lightningTalkTable";
+
+export const MoveToFrontLTButton: Button = {
+    create: (ltId: string) => {
+        return new ButtonBuilder()
+            .setCustomId(`priority-lt-${ltId}`)
+            .setLabel('このLTを先頭に移動')
+            .setStyle(ButtonStyle.Secondary)
+    },
+    isThisButton: (interaction) => {
+        return interaction.customId.startsWith('priority-lt-');
+    },
+    onClick: async (interaction) => {
+        await interaction.deferUpdate();
+        const ltId = interaction.customId.split('-')[2];
+        if (!ltId || isNaN(parseInt(ltId))) {
+            console.error('ltId is empty');
+            await interaction.editReply({ content: interaction.message.content + '\nFailed to change priority due to parsing error' });
+            return;
+        }
+
+        const maxPriority = await getMaxPriorityLT(interaction.user.id);
+        const { lt, error } = await updatePriority(parseInt(ltId), maxPriority + 1);
+
+        if (error || !lt) {
+            console.error('Failed to change priority', error);
+            await interaction.editReply({ content: interaction.message.content + '\nFailed to change priority' });
+            return;
+        }
+        await interaction.editReply({ content: interaction.message.content + '\nLTの優先度を変更し、先頭に移動しました' });
+    }
+}

--- a/src/buttons/moveToFrontLTButton.ts
+++ b/src/buttons/moveToFrontLTButton.ts
@@ -1,4 +1,4 @@
-import { ButtonBuilder, ButtonStyle } from "discord.js";
+import { ActionRowBuilder, ButtonBuilder, ButtonComponent, ButtonStyle, type MessageActionRowComponent } from "discord.js";
 import type { Button } from "../types";
 import { getMaxPriorityLT, updatePriority } from "../tables/lightningTalkTable";
 
@@ -29,6 +29,10 @@ export const MoveToFrontLTButton: Button = {
             await interaction.editReply({ content: interaction.message.content + '\nFailed to change priority' });
             return;
         }
-        await interaction.editReply({ content: interaction.message.content + '\nLTの優先度を変更し、先頭に移動しました' });
+
+        await interaction.editReply({
+            content: '先頭に移動しました',
+            components: []
+        });
     }
 }

--- a/src/commands/editLTCommand.ts
+++ b/src/commands/editLTCommand.ts
@@ -17,7 +17,7 @@ export const editLTCommand: Command = {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         const select = await editLTsStringSelectMenu.create(interaction.user.id);
         if (!select) {
-            await interaction.editReply('Failed to get your LTs');
+            await interaction.editReply('あなたのLTが存在しません');
             return;
         }
 

--- a/src/commands/editLTCommand.ts
+++ b/src/commands/editLTCommand.ts
@@ -25,7 +25,7 @@ export const editLTCommand: Command = {
             .addComponents(select);
 
         await interaction.editReply({
-            content: 'Choose your starter!',
+            content: '編集したいLTを選択してください',
             components: [row],
         });
     }

--- a/src/stringSelectMenus/editLTsStringSelectMenu.ts
+++ b/src/stringSelectMenus/editLTsStringSelectMenu.ts
@@ -4,7 +4,6 @@ import { getLTById, getLTsBySpeaker } from "../tables/lightningTalkTable";
 import { deleteLTButton } from "../buttons/deleteLTButton";
 import { readyLTButton } from "../buttons/readyLTButton";
 import { unreadyLTButton } from "../buttons/unreadyLTButtons";
-import { moveNextLTButton } from "../buttons/moveNextLTButton";
 import { MoveToFrontLTButton } from "../buttons/moveToFrontLTButton";
 
 
@@ -27,7 +26,7 @@ export const editLTsStringSelectMenu: StringSelectMenu = {
             .addOptions(
                 lts.map(lt => {
                     return new StringSelectMenuOptionBuilder()
-                        .setLabel(lt.title)
+                        .setLabel(`「${lt.title}」 (${lt.state === "READY" ? "準備中" : "発表可能"}): 優先度${lt.priority}`)
                         .setValue(lt.id.toString())
                 })
             );

--- a/src/stringSelectMenus/editLTsStringSelectMenu.ts
+++ b/src/stringSelectMenus/editLTsStringSelectMenu.ts
@@ -4,6 +4,8 @@ import { getLTById, getLTsBySpeaker } from "../tables/lightningTalkTable";
 import { deleteLTButton } from "../buttons/deleteLTButton";
 import { readyLTButton } from "../buttons/readyLTButton";
 import { unreadyLTButton } from "../buttons/unreadyLTButtons";
+import { moveNextLTButton } from "../buttons/moveNextLTButton";
+import { MoveToFrontLTButton } from "../buttons/moveToFrontLTButton";
 
 
 export const editLTsStringSelectMenu: StringSelectMenu = {
@@ -50,7 +52,8 @@ export const editLTsStringSelectMenu: StringSelectMenu = {
 
         const row = new ActionRowBuilder<ButtonBuilder>()
             .addComponents(deleteLTButton.create(lt.id.toString()))
-            .addComponents(lt.state === "UNREADY" ? unreadyLTButton.create(lt.id.toString()) : readyLTButton.create(lt.id.toString()));
+            .addComponents(lt.state === "UNREADY" ? unreadyLTButton.create(lt.id.toString()) : readyLTButton.create(lt.id.toString()))
+            .addComponents(MoveToFrontLTButton.create(lt.id.toString()))
 
         await interaction.editReply({
             content: ltInfoString,

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -197,10 +197,10 @@ export const getNextReadyLTs = async (limit: number): Promise<{ lts: LightningTa
             where: {
                 state: 'READY'
             },
-            orderBy: {
-                priority: 'desc',
-                updatedAt: 'asc'
-            }
+            orderBy: [
+                { priority: 'desc' },
+                { updatedAt: 'asc' }
+            ]
         });
 
         const speakerDoneCounts = await prisma.lightningTalk.groupBy({
@@ -258,7 +258,11 @@ export const getLTsBySpeaker = async (speaker: string, includeDone: boolean = fa
                 } : {
                     notIn: ['DONE', 'DOING']
                 }
-            }
+            },
+            orderBy: [
+                { state: 'asc' },
+                { priority: 'desc' }
+            ]
         });
 
         console.log('getLTsBySpeaker', lts);

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -301,3 +301,33 @@ export const getMaxPriorityLT = async (discordUserId: string): Promise<number> =
         console.log('end getMaxPriorityLT');
     }
 }
+
+
+export const updatePriority = async (ltId: number, priority: number): Promise<{ lt: LightningTalk | null, error: any }> => {
+    console.log('start updatePriority');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const lt = await prisma.lightningTalk.update({
+            where: {
+                id: ltId
+            },
+            data: {
+                priority
+            }
+        });
+
+        console.log('updatePriority', lt);
+
+        return { lt, error: null };
+
+    } catch (error: any) {
+        console.error('Failed to updatePriority', error);
+        return { lt: null, error };
+
+    } finally {
+        await prisma.$disconnect();
+        console.log('end updatePriority');
+    }
+}

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -273,3 +273,31 @@ export const getLTsBySpeaker = async (speaker: string, includeDone: boolean = fa
     }
 }
 
+export const getMaxPriorityLT = async (discordUserId: string): Promise<number> => {
+    console.log('start getMaxPriorityLT');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const lts = await prisma.lightningTalk.findMany({
+            where: {
+                speaker: discordUserId
+            },
+            orderBy: {
+                priority: 'desc'
+            }
+        });
+
+        console.log('getMaxPriorityLT', lts);
+
+        return lts.length > 0 ? lts[0].priority : 0;
+
+    } catch (error: any) {
+        console.error('Failed to getMaxPriorityLT', error);
+        return 0;
+
+    } finally {
+        await prisma.$disconnect();
+        console.log('end getMaxPriorityLT');
+    }
+}

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -180,7 +180,8 @@ export const updateLTStateById = async (id: number, state: State): Promise<{ lt:
  * 次に発表する準備ができているLightning Talkのリストを取得します。
  * 以下の順で、speakerの重複がないように取得します。
  * 1. 発表済みの回数が少ない順
- * 2. 更新日時が古い順
+ * 2. priorityが高い順
+ * 3. 更新日時が古い順
  * 
  * @param {number} limit - 取得するLightning Talkの最大数
  * @returns {Promise<{ lts: LightningTalk[] | null, error: any }>} 取得されたLightning Talkのリストとエラー情報を含むPromise
@@ -197,6 +198,7 @@ export const getNextReadyLTs = async (limit: number): Promise<{ lts: LightningTa
                 state: 'READY'
             },
             orderBy: {
+                priority: 'desc',
                 updatedAt: 'asc'
             }
         });
@@ -216,7 +218,7 @@ export const getNextReadyLTs = async (limit: number): Promise<{ lts: LightningTa
         const speakerSet = new Set<string>();   // filter用のSet
 
         const sortedReadyLTs = readyLTs
-            // [WHY] 同じスピーカーが複数回発表しないようにするためのfilter（最初に現れたものを採用 i.e. updatedAtが古いものを採用）
+            // [WHY] 同じスピーカーが複数回発表しないようにするためのfilter（最初に現れたものを採用 i.e. priorityが高い → updatedAtが古いものを採用）
             .filter(lt => {
                 if (speakerSet.has(lt.speaker)) {
                     return false;


### PR DESCRIPTION
This pull request introduces a new feature to manage the priority of Lightning Talks, allowing users to move a talk to the front of the queue. Additionally, it includes some localization improvements and updates to the sorting logic for Lightning Talks.

### Priority Management for Lightning Talks:
* Added a new `priority` field to the `LightningTalk` model in `prisma/schema.prisma` with a default value of 0.
* Introduced the `MoveToFrontLTButton` in `src/buttons/moveToFrontLTButton.ts` to allow users to move a Lightning Talk to the front of the queue.
* Updated the buttons index in `src/buttons/index.ts` to include the `MoveToFrontLTButton`.

### Localization Improvements:
* Updated the `editLTCommand` in `src/commands/editLTCommand.ts` to use Japanese messages for better localization.
* Enhanced the `editLTsStringSelectMenu` in `src/stringSelectMenus/editLTsStringSelectMenu.ts` to display Lightning Talk titles with their state and priority in Japanese.

### Sorting Logic Updates:
* Modified the `getNextReadyLTs` function in `src/tables/lightningTalkTable.ts` to prioritize Lightning Talks based on their `priority` before considering the `updatedAt` timestamp.
* Adjusted the `getLTsBySpeaker` function in `src/tables/lightningTalkTable.ts` to sort by `state` and `priority`.

These changes collectively enhance the user experience by allowing better management of Lightning Talk priorities and improving localization.