### PR TITLE
リアクションによる投票を可能に

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model NextLightningTalk {
   lightningTalk   LightningTalk @relation(fields: [lightningTalkId], references: [id], onDelete: Cascade)
   lightningTalkId Int           @unique @map("lightning_talk_id")
   order           Int           @unique
+  done            Boolean       @default(false)
   createdAt       DateTime      @default(now()) @map("created_at")
   updatedAt       DateTime      @updatedAt @map("updated_at")
 

--- a/src/services/LTNotificationService.ts
+++ b/src/services/LTNotificationService.ts
@@ -2,7 +2,7 @@ import { ActionRowBuilder, ButtonBuilder, CommandInteraction, roleMention, userM
 import type { LightningTalk } from "@prisma/client";
 import { insertNotificationMessage } from "../tables/notificationMessageTable";
 import { getNextReadyLTs, updateLTStateById } from "../tables/lightningTalkTable";
-import { deleteNextLT, getNextLT, insertNextLTs } from "../tables/nextLightningTalkTable";
+import { deleteAllNextLTs, getAllDoneNextLTs, getNextLT, insertNextLTs, updateDoneNextLT } from "../tables/nextLightningTalkTable";
 import { moveNextLTButton } from "../buttons/moveNextLTButton";
 
 const { NOTIFICATION_CHANNEL_ID, ROLE_ID } = process.env;
@@ -138,10 +138,10 @@ export const moveNextLT = async (client: Client, isFirst: boolean = false) => {
             return;
         }
 
-        const { error: deleteNextLTError } = await deleteNextLT(doneLT.id);
+        const { error: nextDoneLTError } = await updateDoneNextLT(doneLT.id);
 
-        if (deleteNextLTError) {
-            console.error('Failed to delete next LT', deleteNextLTError);
+        if (nextDoneLTError) {
+            console.error('Failed to be done next LT', nextDoneLTError);
             return;
         }
     }
@@ -165,13 +165,31 @@ export const moveNextLT = async (client: Client, isFirst: boolean = false) => {
                 nextLT.lightningTalk.description ? `概要：${nextLT.lightningTalk.description}` : '',
             ].filter(Boolean).join('\n')
             :
-            `${roleMention(ROLE_ID)}\nこのセッションにおける全てのLTが終了しました！`;
+            `${roleMention(ROLE_ID)}\nこのセッションにおける全てのLTが終了しました！\n投票をお願いします！`;
 
     const row = new ActionRowBuilder<ButtonBuilder>()
         .addComponents(moveNextLTButton.create())
 
     const sendMessage = await channel?.send({ content: notificationMessageContent, components: nextLT ? [row] : [] });
     console.log('sendMessage', sendMessage.content);
+
+    if (!nextLT) {
+        const { nextLTs, error } = await getAllDoneNextLTs();
+        if (error || !nextLTs) {
+            console.error('Failed to get all done next LTs', error);
+            return;
+        }
+        nextLTs.map(async (nextLT) => {
+            const message = await channel?.send(
+                `「${nextLT.lightningTalk.title}」 発表者：${userMention(nextLT.lightningTalk.speaker)}`
+            )
+            await message.react('🥇');
+            await message.react('🥈');
+        }
+        );
+
+        await deleteAllNextLTs();
+    }
 
     console.log('end moveNextLT');
 }

--- a/src/tables/nextLightningTalkTable.ts
+++ b/src/tables/nextLightningTalkTable.ts
@@ -86,6 +86,9 @@ export const getNextLT = async (): Promise<{ nextLT: NextLightningTalkWithDetail
                     }
                 }
             },
+            where: {
+                done: false
+            },
             orderBy: {
                 order: 'asc'
             }

--- a/src/tables/nextLightningTalkTable.ts
+++ b/src/tables/nextLightningTalkTable.ts
@@ -44,7 +44,7 @@ export const insertNextLTs = async (lightningTalkIds: number[]): Promise<{ nextL
  * 
  * @returns {Promise<{ count: number | null, error: any }>} 削除されたレコードの数とエラー情報を含むPromise
  */
-const deleteAllNextLTs = async (): Promise<{ count: number | null, error: any }> => {
+export const deleteAllNextLTs = async (): Promise<{ count: number | null, error: any }> => {
     console.log('start deleteAllNextLTs');
 
     const prisma = new PrismaClient();
@@ -133,3 +133,66 @@ export const deleteNextLT = async (nextLTId: number): Promise<{ nextLT: NextLigh
         console.log('end deleteNextLT');
     }
 }
+
+export const updateDoneNextLT = async (nextLTId: number): Promise<{ nextLT: NextLightningTalk | null, error: any }> => {
+    console.log('start updateDoneNextLT');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const nextLT: NextLightningTalk = await prisma.nextLightningTalk.update({
+            where: {
+                id: nextLTId
+            },
+            data: {
+                done: true
+            }
+        });
+        console.log('updateDoneNextLT', nextLT);
+
+        return { nextLT, error: null };
+    } catch (error: any) {
+        console.error('Failed to updateDoneNextLT', error);
+        return { nextLT: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end updateDoneNextLT');
+    }
+}
+
+export const getAllDoneNextLTs = async (): Promise<{ nextLTs: NextLightningTalkWithDetails[] | null, error: any }> => {
+    console.log('start getAllDoneNextLTs');
+
+    const prisma = new PrismaClient();
+
+    try {
+        const nextLTs: NextLightningTalkWithDetails[] = await prisma.nextLightningTalk.findMany({
+            include: {
+                lightningTalk: {
+                    select: {
+                        id: true,
+                        title: true,
+                        speaker: true,
+                        description: true
+                    }
+                }
+            },
+            where: {
+                done: true
+            },
+            orderBy: {
+                order: 'asc'
+            }
+        });
+        console.log('getAllDoneNextLTs', nextLTs);
+
+        return { nextLTs, error: null };
+    } catch (error: any) {
+        console.error('Failed to getAllDoneNextLTs', error);
+        return { nextLTs: null, error };
+    } finally {
+        await prisma.$disconnect();
+        console.log('end getAllDoneNextLTs');
+    }
+}
+


### PR DESCRIPTION
This pull request includes several changes to the `NextLightningTalk` model and related services to improve the handling of completed lightning talks. The most important changes include adding a new `done` field to the `NextLightningTalk` model, updating the logic for handling completed talks, and adding new methods to manage the state of these talks.

Model updates:

* Added a new `done` field to the `NextLightningTalk` model to track completion status. (`prisma/schema.prisma`, [prisma/schema.prismaR54](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR54))

Service updates:

* Updated the `LTNotificationService` to use the new `done` field and added logic to handle completed talks, including sending notifications and updating the state. (`src/services/LTNotificationService.ts`, [[1]](diffhunk://#diff-70bd06a9dfe5a43486726cc9cb728a9b2b47b9e05614263cc50912b928c23cbfL5-R5) [[2]](diffhunk://#diff-70bd06a9dfe5a43486726cc9cb728a9b2b47b9e05614263cc50912b928c23cbfL141-R144) [[3]](diffhunk://#diff-70bd06a9dfe5a43486726cc9cb728a9b2b47b9e05614263cc50912b928c23cbfL168-R193)

Database operations:

* Added new methods `updateDoneNextLT` and `getAllDoneNextLTs` to manage the state of completed lightning talks and retrieve all completed talks. (`src/tables/nextLightningTalkTable.ts`, [src/tables/nextLightningTalkTable.tsR136-R198](diffhunk://#diff-f3fefeaea19376967217df637a6dda23b13bba3c38a10c4984c215506a40b016R136-R198))
* Modified existing methods to incorporate the `done` field, ensuring only incomplete talks are retrieved. (`src/tables/nextLightningTalkTable.ts`, [src/tables/nextLightningTalkTable.tsR89-R91](diffhunk://#diff-f3fefeaea19376967217df637a6dda23b13bba3c38a10c4984c215506a40b016R89-R91))
* Exported the `deleteAllNextLTs` method for external use. (`src/tables/nextLightningTalkTable.ts`, [src/tables/nextLightningTalkTable.tsL47-R47](diffhunk://#diff-f3fefeaea19376967217df637a6dda23b13bba3c38a10c4984c215506a40b016L47-R47))