### PR TITLE
編集時のselect menu のデバッグ

### DIFF
--- a/src/stringSelectMenus/editLTsStringSelectMenu.ts
+++ b/src/stringSelectMenus/editLTsStringSelectMenu.ts
@@ -22,7 +22,7 @@ export const editLTsStringSelectMenu: StringSelectMenu = {
 
         return new StringSelectMenuBuilder()
             .setCustomId(`my-lts-${discordUserId}`)
-            .setPlaceholder('編集したいLTを選択してください')
+            .setPlaceholder('発表順に並んでいます')
             .addOptions(
                 lts.map(lt => {
                     return new StringSelectMenuOptionBuilder()

--- a/src/tables/lightningTalkTable.ts
+++ b/src/tables/lightningTalkTable.ts
@@ -260,7 +260,7 @@ export const getLTsBySpeaker = async (speaker: string, includeDone: boolean = fa
                 }
             },
             orderBy: [
-                { state: 'asc' },
+                { state: 'desc' },
                 { priority: 'desc' }
             ]
         });


### PR DESCRIPTION
This pull request includes changes to improve the user interface and sorting functionality in the `editLTsStringSelectMenu` and `lightningTalkTable` modules. The most important changes are:

User Interface Improvements:
* [`src/stringSelectMenus/editLTsStringSelectMenu.ts`](diffhunk://#diff-556a6fc4d25e31de45d76e456194d100ddcbaca5015bd4bd2161835a019978b0L25-R25): Updated the placeholder text in the `StringSelectMenu` to indicate that items are ordered by presentation sequence.

Sorting Functionality:
* [`src/tables/lightningTalkTable.ts`](diffhunk://#diff-3583c66008e0d94dd4c0e8b1066202e00319287fdccc2d82b592eed8bded287cL263-R263): Changed the sorting order of the `state` field from ascending to descending to prioritize different states accordingly.